### PR TITLE
fix: Gradle wrapper JDK21 fallback for Java 25; enhance Python sandbox tools and download links

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -158,7 +158,17 @@ kotlin {
 chaquopy {
     defaultConfig {
         version = "3.11"
-        buildPython("C:/Users/julia/AppData/Local/Programs/Python/Python311/python.exe")
+
+        // Allow local/CI environments to override Python discovery instead of relying
+        // on a machine-specific Windows path.
+        val configuredBuildPython = providers.gradleProperty("chaquopy.buildPython").orNull
+            ?: System.getenv("CHAQUOPY_BUILD_PYTHON")
+            ?: System.getenv("PYTHON")
+            ?: System.getenv("PYTHON3")
+        if (!configuredBuildPython.isNullOrBlank()) {
+            buildPython(configuredBuildPython)
+        }
+
         pip {
             // Core data science  
             install("numpy")

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/LocalTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/LocalTools.kt
@@ -5,6 +5,7 @@ import com.whl.quickjs.wrapper.QuickJSContext
 import com.whl.quickjs.wrapper.QuickJSObject
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.booleanOrNull
@@ -70,13 +71,31 @@ class LocalTools(private val context: Context) {
         return listOf(
             Tool(
                 name = "eval_python",
-                description = "Execute Python code. Has access to numpy and Pillow. Returns result or stdout. Use for calculations, data processing, and file manipulation.",
+                description = "Execute Python code. Has access to numpy, pandas, matplotlib and Pillow. Use for calculations, data processing and chart/image generation. If attachments are present in the latest user message, pass them via `attachments` to auto-import before execution. After execution, check `generated_files` and include any `markdown_link` in your reply (for images prefer Markdown image syntax like `![chart](content://...)`).",
                 parameters = {
                     InputSchema.Obj(
                         properties = buildJsonObject {
                             put("code", buildJsonObject {
                                 put("type", "string")
                                 put("description", "The Python code to execute")
+                            })
+                            put("attachments", buildJsonObject {
+                                put("type", "array")
+                                put("description", "Optional attachments to auto-import into sandbox before running code")
+                                put("items", buildJsonObject {
+                                    put("type", "object")
+                                    put("properties", buildJsonObject {
+                                        put("url", buildJsonObject {
+                                            put("type", "string")
+                                            put("description", "Attachment URL from chat message")
+                                        })
+                                        put("filename", buildJsonObject {
+                                            put("type", "string")
+                                            put("description", "Target filename in sandbox")
+                                        })
+                                    })
+                                    put("required", JsonArray(listOf(JsonPrimitive("url"), JsonPrimitive("filename"))))
+                                })
                             })
                         },
                         required = listOf("code")
@@ -85,20 +104,80 @@ class LocalTools(private val context: Context) {
                 execute = {
                     val code = it.jsonObject["code"]?.jsonPrimitive?.contentOrNull ?: ""
                     try {
+                        val filesBefore = pythonSandbox.listFiles(conversationId)
+                        val beforeNames = filesBefore.map { file -> file.name }.toSet()
+
+                        val importedAttachments = mutableListOf<kotlinx.serialization.json.JsonObject>()
+                        val attachmentsElement = it.jsonObject["attachments"]
+                        if (attachmentsElement is JsonArray) {
+                            attachmentsElement.forEach { item ->
+                                val itemObj = item as? kotlinx.serialization.json.JsonObject ?: return@forEach
+                                val url = itemObj["url"]?.jsonPrimitive?.contentOrNull
+                                val filename = itemObj["filename"]?.jsonPrimitive?.contentOrNull
+                                if (!url.isNullOrBlank() && !filename.isNullOrBlank()) {
+                                    runCatching {
+                                        val savedPath = pythonSandbox.importFile(conversationId, android.net.Uri.parse(url), filename)
+                                        buildJsonObject {
+                                            put("url", url)
+                                            put("filename", filename)
+                                            put("path", savedPath)
+                                            put("success", true)
+                                        }
+                                    }.onSuccess { importedAttachments.add(it) }
+                                        .onFailure { error ->
+                                            importedAttachments.add(
+                                                buildJsonObject {
+                                                    put("url", url)
+                                                    put("filename", filename)
+                                                    put("success", false)
+                                                    put("error", error.message ?: "Failed to import attachment")
+                                                }
+                                            )
+                                        }
+                                }
+                            }
+                        }
+
                         val python = com.chaquo.python.Python.getInstance()
                         val executor = python.getModule("executor")
                         val resultJson = executor.callAttr("execute", code, workingDir).toString()
-                        val resultObj = kotlinx.serialization.json.Json.parseToJsonElement(resultJson).jsonObject
-                        
+                        val baseResultObj = kotlinx.serialization.json.Json.parseToJsonElement(resultJson).jsonObject
+
+                        val filesAfter = pythonSandbox.listFiles(conversationId)
+                        val generatedFiles = filesAfter
+                            .filter { file -> !beforeNames.contains(file.name) }
+                            .map { file ->
+                                val uri = pythonSandbox.getFileUri(conversationId, file.name)
+                                buildJsonObject {
+                                    put("name", file.name)
+                                    put("size", file.size)
+                                    put("is_image", file.isImage)
+                                    put("mime", file.mimeType)
+                                    put("uri", uri.toString())
+                                    put("markdown_link", if (file.isImage) "![${file.name}]($uri)" else "[${file.name}]($uri)")
+                                }
+                            }
+
+                        val finalResultObj = buildJsonObject {
+                            baseResultObj.forEach { (k, v) -> put(k, v) }
+                            if (importedAttachments.isNotEmpty()) {
+                                put("imported_attachments", JsonArray(importedAttachments))
+                            }
+                            if (generatedFiles.isNotEmpty()) {
+                                put("generated_files", JsonArray(generatedFiles))
+                                put("note", "Use generated_files[].markdown_link in your reply so users can open/download outputs directly in chat.")
+                            }
+                        }
+
                         // Truncate output if too long
-                        val output = resultObj.toString()
+                        val output = finalResultObj.toString()
                         if (output.length > 2000) {
                             buildJsonObject {
                                 put("output", output.take(2000) + "... (truncated)")
-                                put("note", "Output truncated to save context window. Use print() sparingly or save to file.")
+                                put("note", "Output truncated to save context window. Use print() sparingly or save to file, and use list_sandbox_files to inspect files.")
                             }
                         } else {
-                            resultObj
+                            finalResultObj
                         }
                     } catch (e: Exception) {
                         buildJsonObject { put("error", e.message ?: "Unknown error") }
@@ -107,7 +186,7 @@ class LocalTools(private val context: Context) {
             ),
             Tool(
                 name = "list_sandbox_files",
-                description = "List all files in the Python sandbox for this conversation. Returns file names, sizes, and whether they are images.",
+                description = "List all files in the Python sandbox for this conversation. Returns file names, sizes, whether they are images, and direct markdown links you can include in your response.",
                 parameters = {
                     InputSchema.Obj(
                         properties = buildJsonObject { },
@@ -121,9 +200,13 @@ class LocalTools(private val context: Context) {
                             put("files", kotlinx.serialization.json.JsonArray(
                                 files.map { file ->
                                     buildJsonObject {
+                                        val uri = pythonSandbox.getFileUri(conversationId, file.name)
                                         put("name", file.name)
                                         put("size", file.size)
                                         put("is_image", file.isImage)
+                                        put("mime", file.mimeType)
+                                        put("uri", uri.toString())
+                                        put("markdown_link", if (file.isImage) "![${file.name}]($uri)" else "[${file.name}]($uri)")
                                     }
                                 }
                             ))
@@ -231,7 +314,7 @@ class LocalTools(private val context: Context) {
             ),
             Tool(
                 name = "import_attachment",
-                description = "Import an attached file from the user's message into the Python sandbox. Use the file URL from image/document attachments in the conversation. Returns the path where the file was saved.",
+                description = "Import an attached file from the user's message into the Python sandbox. Use the file URL from image/document attachments in the conversation. Tip: you can also pass multiple attachments directly in eval_python.attachments for automatic import.",
                 parameters = {
                     InputSchema.Obj(
                         properties = buildJsonObject {

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/UnsupportedFileTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/UnsupportedFileTransformer.kt
@@ -38,7 +38,7 @@ object UnsupportedFileTransformer : InputMessageTransformer {
                                          part.mime == "application/pdf"
                             
                             if (!isNative) {
-                                 UIMessagePart.Text("\n[Attachment: ${part.fileName} (${part.mime}) - Available for Python import via import_attachment tool. URL: ${part.url}]\n")
+                                 UIMessagePart.Text("\n[Attachment: ${part.fileName} (${part.mime}) - Available for Python via eval_python.attachments (auto-import) or import_attachment tool. After running, use list_sandbox_files to verify files. URL: ${part.url}]\n")
                             } else {
                                 part
                             }
@@ -48,7 +48,7 @@ object UnsupportedFileTransformer : InputMessageTransformer {
                             // convert to text annotation so model can import via Python
                             if (!modelSupportsImages) {
                                 val filename = part.url.substringAfterLast("/").substringBefore("?").ifEmpty { "image.jpg" }
-                                UIMessagePart.Text("\n[Image attachment: $filename - Available for Python import via import_attachment tool. URL: ${part.url}]\n")
+                                UIMessagePart.Text("\n[Image attachment: $filename - Available for Python via eval_python.attachments (auto-import) or import_attachment tool. After running, use list_sandbox_files to verify files. URL: ${part.url}]\n")
                             } else {
                                 part
                             }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -1099,7 +1099,7 @@ private fun AnnotatedString.Builder.appendMarkdownNodeContent(
                 inlineContents.putIfAbsent(
                     inlineKey, InlineTextContent(
                         placeholder = Placeholder(
-                            width = (displayName.length * 8 + 8).sp, // Width for link text
+                            width = (displayName.length * 12 + 32).sp, // Extra width to avoid clipping long download link text
                             height = (style.fontSize.value * 1.3f).sp, // Extra height for descenders (p, g, y)
                             placeholderVerticalAlign = PlaceholderVerticalAlign.TextBottom,
                         ), children = {

--- a/gradlew
+++ b/gradlew
@@ -105,6 +105,33 @@ Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
 fi
 
+# Gradle/Kotlin in this repository currently fails on JDK 25+ during script evaluation
+# (IllegalArgumentException while parsing Java version). If we detect 25+, auto-fallback
+# to a local JDK 21 installation when available.
+JAVA_VERSION_OUTPUT=`"$JAVACMD" -version 2>&1 | sed -n '1p'`
+JAVA_VERSION_RAW=`echo "$JAVA_VERSION_OUTPUT" | sed -n 's/.*version "\([^"]*\)".*/\1/p'`
+JAVA_VERSION_MAJOR=`echo "$JAVA_VERSION_RAW" | cut -d. -f1`
+if [ "$JAVA_VERSION_MAJOR" = "1" ] ; then
+    JAVA_VERSION_MAJOR=`echo "$JAVA_VERSION_RAW" | cut -d. -f2`
+fi
+
+if [ -n "$JAVA_VERSION_MAJOR" ] && [ "$JAVA_VERSION_MAJOR" -ge 25 ] 2>/dev/null ; then
+    for CANDIDATE_HOME in \
+        "$JAVA21_HOME" \
+        "$HOME/.local/share/mise/installs/java/21.0.2" \
+        "$HOME/.local/share/mise/installs/java/21" \
+        "/usr/lib/jvm/java-21-openjdk-amd64" \
+        "/usr/lib/jvm/temurin-21-jdk"
+    do
+        if [ -n "$CANDIDATE_HOME" ] && [ -x "$CANDIDATE_HOME/bin/java" ] ; then
+            JAVA_HOME="$CANDIDATE_HOME"
+            JAVACMD="$JAVA_HOME/bin/java"
+            warn "Detected JDK $JAVA_VERSION_RAW; falling back to JDK at $JAVA_HOME for Gradle compatibility."
+            break
+        fi
+    done
+fi
+
 # Increase the maximum file descriptors if we can.
 if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
     MAX_FD_LIMIT=`ulimit -H -n`

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -56,6 +56,23 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
+@rem Gradle/Kotlin in this repository currently fails on JDK 25+ during script evaluation.
+@rem If JAVA_HOME points to 25+, try a local JDK 21 fallback.
+for /f "tokens=3" %%v in ('"%JAVA_EXE%" -version 2^>^&1 ^| findstr /i "version"') do set JAVA_VERSION_RAW=%%~v
+set JAVA_VERSION_RAW=%JAVA_VERSION_RAW:"=%
+for /f "tokens=1 delims=." %%m in ("%JAVA_VERSION_RAW%") do set JAVA_VERSION_MAJOR=%%m
+if "%JAVA_VERSION_MAJOR%"=="25" (
+    if defined JAVA21_HOME if exist "%JAVA21_HOME%\bin\java.exe" (
+        set JAVA_HOME=%JAVA21_HOME%
+        set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+    ) else if exist "%USERPROFILE%\.local\share\mise\installs\java\21.0.2\bin\java.exe" (
+        set JAVA_HOME=%USERPROFILE%\.local\share\mise\installs\java\21.0.2
+        set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+    )
+)
+
+if exist "%JAVA_EXE%" goto execute
+
 echo.
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
 echo.


### PR DESCRIPTION
### Motivation
- The repository failed to evaluate Gradle scripts on environments using JDK 25+ due to Java-version parsing issues that occurred before build evaluation. 
- Python-in-chat workflows needed better attachment import ergonomics and clearer surfaced file outputs so generated artifacts (images/files) can be consumed directly in the chat. 
- Long `content://` download link labels were frequently clipped in the in-app Markdown renderer and needed more inline width budget.

### Description
- Added compatibility fallback logic to the Gradle wrapper scripts (`gradlew` and `gradlew.bat`) that detects Java 25+ and, when present, attempts to automatically switch to a local JDK 21 installation (`JAVA21_HOME`, common mise paths, or common Linux paths) for Gradle compatibility. 
- Enhanced `eval_python` in `LocalTools.kt` to accept an optional `attachments` array for auto-import, to return `imported_attachments` status, and to surface newly created `generated_files` including fields `name`, `size`, `is_image`, `mime`, `uri`, and `markdown_link` (images use `![name](uri)`); also added `note` guidance to encourage models to include `markdown_link` in replies. 
- Updated `list_sandbox_files` and `import_attachment` tool descriptions/outputs to include direct `uri` and `markdown_link` so assistants can include links or images inline. 
- Adjusted transformer text in `UnsupportedFileTransformer.kt` to point models at the `eval_python.attachments` auto-import path and suggest `list_sandbox_files` verification. 
- Made Chaquopy Python discovery in `app/build.gradle.kts` configurable via a `chaquopy.buildPython` Gradle property or `CHAQUOPY_BUILD_PYTHON`/`PYTHON`/`PYTHON3` environment variables instead of a machine-specific Windows hardcoded path. 
- Increased the inline placeholder width calculation in `Markdown.kt` for `content://` links to reduce link-text clipping in the UI.

### Testing
- Ran `java -version` to confirm the environment default was JDK 25 and to validate detection logic, which succeeded. 
- Ran `./gradlew :app:help` and verified the wrapper detects JDK 25 and falls back to a local JDK 21 (log shows fallback message), allowing Gradle to progress beyond the previous JDK parsing failure. 
- The Gradle invocation now proceeds further but fails later during plugin resolution for `com.android.application:8.13.0` (a separate plugin/repository issue), so the JDK parsing problem is resolved while plugin resolution remains an external blocker.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698684ab04f08324938962c839f5aeef)