### PR TITLE
fix: prevent duplicate LazyColumn keys for lorebooks in SettingModesPage

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModesPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModesPage.kt
@@ -1063,7 +1063,7 @@ private fun LorebooksPageContent(
             } else {
                 itemsIndexed(
                     items = settings.lorebooks,
-                    key = { _, lorebook -> "lorebook_${lorebook.id}" }
+                    key = { index, lorebook -> "lorebook_${lorebook.id}_$index" }
                 ) { index, lorebook ->
                     val position = when {
                         settings.lorebooks.size == 1 -> ItemPosition.ONLY


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash in Compose where `IllegalArgumentException: Key "lorebook_..." was already used` occurs when the lorebooks list contains entries with duplicate IDs.

### Description
- Update `itemsIndexed` key in `app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModesPage.kt` to use `"lorebook_${lorebook.id}_$index"` so each LazyColumn item key is guaranteed unique even if IDs repeat.

### Testing
- Attempted to run `./gradlew :app:compileDebugKotlin`, which failed in this environment because the Android SDK location is not configured (`ANDROID_HOME`/`sdk.dir` missing), so no local compile verification could complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987453480c883249eb8d221537e9b45)