### PR TITLE
fix: secure TTS API keys and redact sensitive transport logs

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/transport/SseClientTransport.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/transport/SseClientTransport.kt
@@ -111,7 +111,7 @@ internal class SseClientTransport(
                     type: String?,
                     data: String
                 ) {
-                    Log.i(TAG, "onEvent($baseUrl):  #$id($type) - $data")
+                    Log.i(TAG, "onEvent($baseUrl): id=$id type=$type payloadSize=${data.length}")
                     when (type) {
                         "error" -> {
                             val e = IllegalStateException("SSE error: $data")
@@ -161,7 +161,10 @@ internal class SseClientTransport(
             error("Not connected")
         }
 
-        Log.i(TAG, "send: POSTing to endpoint ${endpoint.getCompleted()} - $message")
+        Log.i(
+            TAG,
+            "send: POSTing to endpoint ${endpoint.getCompleted()} messageType=${message::class.simpleName}"
+        )
 
         try {
             val request = Request.Builder()
@@ -180,7 +183,10 @@ internal class SseClientTransport(
             val response = client.newCall(request).await()
             if (!response.isSuccessful) {
                 val text = response.body.string()
-                error("Error POSTing to endpoint ${endpoint.getCompleted()} (HTTP ${response.code}): $text")
+                error(
+                    "Error POSTing to endpoint ${endpoint.getCompleted()} " +
+                        "(HTTP ${response.code}, bodySize=${text.length})"
+                )
             } else {
                 Log.i(TAG, "send: POST to endpoint ${endpoint.getCompleted()} successful")
             }

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/transport/StreamableHttpClientTransport.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/transport/StreamableHttpClientTransport.kt
@@ -88,7 +88,7 @@ class StreamableHttpClientTransport(
     ) {
         Log.d(
             TAG,
-            "send: Client sending message via POST to $url: ${McpJson.encodeToString(message)}"
+            "send: Client sending message via POST to $url type=${message::class.simpleName}"
         )
 
         // If we have a resumption token, reconnect the SSE stream with it
@@ -276,7 +276,7 @@ class StreamableHttpClientTransport(
                         }
                         Log.d(
                             TAG,
-                            "collectSse: Client received SSE event: event=${event.type}, data=${event.data}, id=${event.id}"
+                            "collectSse: Client received SSE event: event=${event.type}, id=${event.id}, payloadSize=${event.data.length}"
                         )
 
                         when (event.type) {

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/SecretKeyManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/SecretKeyManager.kt
@@ -1,6 +1,7 @@
 package me.rerere.rikkahub.data.datastore
 
 import me.rerere.ai.provider.ProviderSetting
+import me.rerere.tts.provider.TTSProviderSetting
 import kotlin.uuid.Uuid
 
 /**
@@ -18,6 +19,7 @@ class SecretKeyManager(
     companion object {
         private const val PROVIDER_APIKEY_PREFIX = "provider_apikey_"
         private const val PROVIDER_PRIVATEKEY_PREFIX = "provider_privatekey_"
+        private const val TTS_PROVIDER_APIKEY_PREFIX = "tts_provider_apikey_"
         private const val WEBDAV_PASSWORD_KEY = "webdav_password"
     }
 
@@ -72,6 +74,26 @@ class SecretKeyManager(
         secureStore.removeSecret("$PROVIDER_PRIVATEKEY_PREFIX$providerId")
     }
 
+    // ========== TTS API Key Management ==========
+
+    fun getTtsApiKey(providerId: Uuid, plaintextFallback: String): String {
+        val key = "$TTS_PROVIDER_APIKEY_PREFIX$providerId"
+        return secureStore.getSecret(key) ?: plaintextFallback
+    }
+
+    fun setTtsApiKey(providerId: Uuid, apiKey: String) {
+        val key = "$TTS_PROVIDER_APIKEY_PREFIX$providerId"
+        if (apiKey.isNotBlank()) {
+            secureStore.putSecret(key, apiKey)
+        } else {
+            secureStore.removeSecret(key)
+        }
+    }
+
+    fun removeTtsProviderSecrets(providerId: Uuid) {
+        secureStore.removeSecret("$TTS_PROVIDER_APIKEY_PREFIX$providerId")
+    }
+
     // ========== WebDAV Password Management ==========
 
     fun getWebDavPassword(plaintextFallback: String): String {
@@ -113,10 +135,18 @@ class SecretKeyManager(
             settings.webDavConfig
         }
 
+        // Migrate TTS provider API keys
+        val migratedTtsProviders = settings.ttsProviders.map { provider ->
+            migrateTtsProviderSecrets(provider).also {
+                if (it != provider) migrated = true
+            }
+        }
+
         return if (migrated) {
             settings.copy(
                 providers = migratedProviders,
-                webDavConfig = migratedWebDav
+                webDavConfig = migratedWebDav,
+                ttsProviders = migratedTtsProviders
             )
         } else {
             settings
@@ -156,6 +186,40 @@ class SecretKeyManager(
         }
     }
 
+    private fun migrateTtsProviderSecrets(provider: TTSProviderSetting): TTSProviderSetting {
+        return when (provider) {
+            is TTSProviderSetting.OpenAI -> {
+                if (provider.apiKey.isNotBlank()) {
+                    setTtsApiKey(provider.id, provider.apiKey)
+                    provider.copy(apiKey = "")
+                } else provider
+            }
+
+            is TTSProviderSetting.Gemini -> {
+                if (provider.apiKey.isNotBlank()) {
+                    setTtsApiKey(provider.id, provider.apiKey)
+                    provider.copy(apiKey = "")
+                } else provider
+            }
+
+            is TTSProviderSetting.MiniMax -> {
+                if (provider.apiKey.isNotBlank()) {
+                    setTtsApiKey(provider.id, provider.apiKey)
+                    provider.copy(apiKey = "")
+                } else provider
+            }
+
+            is TTSProviderSetting.ElevenLabs -> {
+                if (provider.apiKey.isNotBlank()) {
+                    setTtsApiKey(provider.id, provider.apiKey)
+                    provider.copy(apiKey = "")
+                } else provider
+            }
+
+            is TTSProviderSetting.SystemTTS -> provider
+        }
+    }
+
     // ========== Backup/Export Support ==========
 
     /**
@@ -171,9 +235,14 @@ class SecretKeyManager(
             password = getWebDavPassword(settings.webDavConfig.password)
         )
 
+        val ttsProvidersWithSecrets = settings.ttsProviders.map { provider ->
+            populateTtsProviderSecrets(provider)
+        }
+
         return settings.copy(
             providers = providersWithSecrets,
-            webDavConfig = webDavWithPassword
+            webDavConfig = webDavWithPassword,
+            ttsProviders = ttsProvidersWithSecrets
         )
     }
 
@@ -194,6 +263,28 @@ class SecretKeyManager(
             is ProviderSetting.Claude -> {
                 provider.copy(apiKey = getApiKey(provider.id, provider.apiKey))
             }
+        }
+    }
+
+    private fun populateTtsProviderSecrets(provider: TTSProviderSetting): TTSProviderSetting {
+        return when (provider) {
+            is TTSProviderSetting.OpenAI -> {
+                provider.copy(apiKey = getTtsApiKey(provider.id, provider.apiKey))
+            }
+
+            is TTSProviderSetting.Gemini -> {
+                provider.copy(apiKey = getTtsApiKey(provider.id, provider.apiKey))
+            }
+
+            is TTSProviderSetting.MiniMax -> {
+                provider.copy(apiKey = getTtsApiKey(provider.id, provider.apiKey))
+            }
+
+            is TTSProviderSetting.ElevenLabs -> {
+                provider.copy(apiKey = getTtsApiKey(provider.id, provider.apiKey))
+            }
+
+            is TTSProviderSetting.SystemTTS -> provider
         }
     }
 

--- a/tts/src/main/java/me/rerere/tts/provider/providers/GeminiTTSProvider.kt
+++ b/tts/src/main/java/me/rerere/tts/provider/providers/GeminiTTSProvider.kt
@@ -84,7 +84,11 @@ class GeminiTTSProvider : TTSProvider<TTSProviderSetting.Gemini> {
             put("model", providerSetting.model)
         }
 
-        Log.i(TAG, "generateSpeech: $requestBody")
+        Log.i(
+            TAG,
+            "generateSpeech: model=${providerSetting.model}, " +
+                "voice=${providerSetting.voiceName}, textLength=${request.text.length}"
+        )
 
         val httpRequest = Request.Builder()
             .url("${providerSetting.baseUrl}/models/${providerSetting.model}:generateContent")

--- a/tts/src/main/java/me/rerere/tts/provider/providers/MiniMaxTTSProvider.kt
+++ b/tts/src/main/java/me/rerere/tts/provider/providers/MiniMaxTTSProvider.kt
@@ -65,7 +65,12 @@ class MiniMaxTTSProvider : TTSProvider<TTSProviderSetting.MiniMax> {
             })
         }
 
-        Log.i(TAG, "generateSpeech: $requestBody")
+        Log.i(
+            TAG,
+            "generateSpeech: model=${providerSetting.model}, " +
+                "voice=${providerSetting.voiceId}, emotion=${providerSetting.emotion}, " +
+                "textLength=${request.text.length}"
+        )
 
         val httpRequest = Request.Builder()
             .url("${providerSetting.baseUrl}/t2a_v2")

--- a/tts/src/main/java/me/rerere/tts/provider/providers/OpenAITTSProvider.kt
+++ b/tts/src/main/java/me/rerere/tts/provider/providers/OpenAITTSProvider.kt
@@ -36,7 +36,11 @@ class OpenAITTSProvider : TTSProvider<TTSProviderSetting.OpenAI> {
             put("response_format", "mp3") // Default to MP3
         }
 
-        Log.i(TAG, "generateSpeech: $requestBody")
+        Log.i(
+            TAG,
+            "generateSpeech: model=${providerSetting.model}, " +
+                "voice=${providerSetting.voice}, textLength=${request.text.length}"
+        )
 
         val httpRequest = Request.Builder()
             .url("${providerSetting.baseUrl}/audio/speech")


### PR DESCRIPTION
### Motivation
- TTS provider API keys were stored in plaintext settings and needed the same encrypted lifecycle as other provider secrets. 
- Network/MCP/TTS logs contained raw request/response payloads which risk leaking sensitive user content and credentials.

### Description
- Add TTS secret support in `SecretKeyManager` including a new `tts_provider_apikey_` prefix and `get/set/remove` helpers for TTS provider API keys. 
- Migrate plaintext TTS keys into `SecureStore` during `migrateSecretsFromSettings` and hydrate them for export via `populateSecretsForExport`. 
- Redact verbose payload logging in TTS providers (`OpenAI`, `Gemini`, `MiniMax`) to emit metadata-only logs (`model`, `voice`, `textLength`) instead of raw request bodies. 
- Reduce leakage in MCP transport code (`SseClientTransport`, `StreamableHttpClientTransport`) by logging only message/event type, ids and payload sizes, and replacing full response bodies in error strings with status/size metadata.

### Testing
- Attempted a Kotlin compile check with `./gradlew :app:compileDebugKotlin :tts:compileDebugKotlin :search:compileDebugKotlin -x lint`, which failed due to missing Android SDK configuration (`ANDROID_HOME` / `local.properties sdk.dir`).
- No unit or instrumented test runs were possible in this environment due to the SDK limitation.
- Static verification and diffs were inspected locally to ensure the intended changes (secret handling + logging) were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873c7947f08324a88ad65a9cabae25)