### PR TITLE
fix: target visible assistant content when editing message turns

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatMessageV2.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatMessageV2.kt
@@ -427,6 +427,20 @@ fun ChatMessageTurn(
     
     // Timeline entries from all parts - computed fresh to avoid stale data
     val timelineEntries = buildTimelineEntries(group.allParts)
+
+    // Actions should target the visible assistant content node instead of blindly using lastNode,
+    // because the last node in a turn can be a tool node.
+    val actionTargetNode = remember(group) {
+        group.filteredNodes
+            .asReversed()
+            .firstOrNull { node ->
+                node.currentMessage.parts.any { part ->
+                    part is UIMessagePart.Text || part is UIMessagePart.Reasoning || part is UIMessagePart.Thinking
+                }
+            }
+            ?: group.filteredNodes.lastOrNull()
+            ?: group.lastNode
+    }
     
     ProvideTextStyle(textStyle) {
         when (group.role) {
@@ -497,11 +511,11 @@ fun ChatMessageTurn(
     
     if (showActionsSheet) {
         ChatMessageActionsSheet(
-            message = group.lastNode.currentMessage,
-            onEdit = { onEdit(group.lastNode) },
-            onDelete = { onDelete(group.lastNode) },
-            onShare = { onShare(group.lastNode) },
-            onFork = { onFork(group.lastNode) },
+            message = actionTargetNode.currentMessage,
+            onEdit = { onEdit(actionTargetNode) },
+            onDelete = { onDelete(actionTargetNode) },
+            onShare = { onShare(actionTargetNode) },
+            onFork = { onFork(actionTargetNode) },
             model = model,
             onSelectAndCopy = { showSelectCopySheet = true },
             onWebViewPreview = { },
@@ -511,7 +525,7 @@ fun ChatMessageTurn(
     
     if (showSelectCopySheet) {
         ChatMessageCopySheet(
-            message = group.lastNode.currentMessage,
+            message = actionTargetNode.currentMessage,
             onDismissRequest = { showSelectCopySheet = false }
         )
     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -687,16 +687,16 @@ private fun ChatPageContent(
                                 }
                             },
                             onSendClick = {
-                                if (currentChatModel == null) {
-                                    toaster.show("Please select a model first", type = ToastType.Error)
-                                    return@MinimalChatInput
-                                }
                                 if (inputState.isEditing()) {
                                     vm.handleMessageEdit(
                                         parts = inputState.getContents(),
                                         messageId = inputState.editingMessage!!,
                                     )
                                 } else {
+                                    if (currentChatModel == null) {
+                                        toaster.show("Please select a model first", type = ToastType.Error)
+                                        return@MinimalChatInput
+                                    }
                                     vm.handleMessageSend(inputState.getContents(), isTemporaryChat = isTemporaryChat)
                                     scope.launch {
                                         chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
@@ -711,6 +711,10 @@ private fun ChatPageContent(
                                         messageId = inputState.editingMessage!!,
                                     )
                                 } else {
+                                    if (currentChatModel == null) {
+                                        toaster.show("Please select a model first", type = ToastType.Error)
+                                        return@MinimalChatInput
+                                    }
                                     vm.handleMessageSend(content = inputState.getContents(), answer = false, isTemporaryChat = isTemporaryChat)
                                     scope.launch {
                                         chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
@@ -788,16 +792,16 @@ private fun ChatPageContent(
                                 }
                             },
                             onSendClick = {
-                                if (currentChatModel == null) {
-                                    toaster.show("Please select a model first", type = ToastType.Error)
-                                    return@ChatInput
-                                }
                                 if (inputState.isEditing()) {
                                     vm.handleMessageEdit(
                                         parts = inputState.getContents(),
                                         messageId = inputState.editingMessage!!,
                                     )
                                 } else {
+                                    if (currentChatModel == null) {
+                                        toaster.show("Please select a model first", type = ToastType.Error)
+                                        return@ChatInput
+                                    }
                                     vm.handleMessageSend(inputState.getContents(), isTemporaryChat = isTemporaryChat)
                                     scope.launch {
                                         chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
@@ -812,6 +816,10 @@ private fun ChatPageContent(
                                         messageId = inputState.editingMessage!!,
                                     )
                                 } else {
+                                    if (currentChatModel == null) {
+                                        toaster.show("Please select a model first", type = ToastType.Error)
+                                        return@ChatInput
+                                    }
                                     vm.handleMessageSend(content = inputState.getContents(), answer = false, isTemporaryChat = isTemporaryChat)
                                     scope.launch {
                                         chatListState.requestScrollToItem(conversation.currentMessages.size + 5)


### PR DESCRIPTION
### Motivation
- Edits applied to assistant turns were sometimes acting on a trailing tool node (creating apparent duplicates) because action handlers used `group.lastNode` instead of the visible assistant content node. 
- Editing was also blocked earlier when no model was selected due to model-selection validation running before the edit path in input handlers. 

### Description
- Added `actionTargetNode` selection in `ChatMessageTurn` that prefers the last filtered node containing `Text`, `Reasoning`, or `Thinking` parts, with fallbacks to the last filtered node and then `lastNode`.
- Wired `ChatMessageActionsSheet` and `ChatMessageCopySheet` to use `actionTargetNode` for `message`, `onEdit`, `onDelete`, `onShare`, and `onFork` so actions target the visible assistant content.
- Updated input handlers in `ChatPage.kt` (both `MinimalChatInput` and `ChatInput` send/long-send handlers) to perform the model-selection check only for new-send branches and allow `handleMessageEdit` to run unconditionally so edits can be saved without a selected model.
- Changes touch `app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatMessageV2.kt` and `app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt`.

### Testing
- Verified diffs and code locations with `rg` and inspected modified files with `sed` to ensure `actionTargetNode` is used and edit-first flow is implemented (inspection succeeded).
- Attempted `./gradlew :app:compileDebugKotlin` but the build failed due to missing Android SDK configuration (`ANDROID_HOME` / `local.properties sdk.dir`), so a full compile could not be performed.
- Committed the change after local static inspection; no automated compile or unit test succeeded due to the environment SDK limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698793fa14fc83248f9979655798f092)