### PR TITLE
feat: restyle "no models" warning card and default to OpenRouter only

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/DefaultProviders.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/DefaultProviders.kt
@@ -9,75 +9,12 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import me.rerere.ai.provider.BalanceOption
-import me.rerere.ai.provider.Modality
-import me.rerere.ai.provider.Model
-import me.rerere.ai.provider.ModelAbility
 import me.rerere.ai.provider.ProviderSetting
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.ui.components.richtext.MarkdownBlock
 import kotlin.uuid.Uuid
 
-val GEMINI_2_5_FLASH_ID = Uuid.parse("5f4d3c2b-1a0e-9d8c-7b6a-543210fedcba")
-
 val DEFAULT_PROVIDERS = listOf(
-    ProviderSetting.OpenAI(
-        id = Uuid.parse("1eeea727-9ee5-4cae-93e6-6fb01a4d051e"),
-        name = "OpenAI",
-        baseUrl = "https://api.openai.com/v1",
-        apiKey = "",
-        builtIn = true,
-        models = listOf(
-            Model(
-                id = Uuid.parse("ea7b9574-e590-42ac-a9ac-01e3aa213f4f"),
-                modelId = "gpt-4o",
-                displayName = "GPT-4o",
-                inputModalities = listOf(Modality.TEXT, Modality.IMAGE),
-                outputModalities = listOf(Modality.TEXT),
-                abilities = listOf(ModelAbility.TOOL, ModelAbility.REASONING),
-            ),
-            Model(
-                id = Uuid.parse("5c33502d-2307-40bd-83fc-133f504bb0c9"),
-                modelId = "gpt-4o-mini",
-                displayName = "GPT-4o Mini",
-                inputModalities = listOf(Modality.TEXT, Modality.IMAGE),
-                outputModalities = listOf(Modality.TEXT),
-                abilities = listOf(ModelAbility.TOOL, ModelAbility.REASONING),
-            ),
-        )
-    ),
-    ProviderSetting.Google(
-        id = Uuid.parse("6ab18148-c138-4394-a46f-1cd8c8ceaa6d"),
-        name = "Google",
-        apiKey = "",
-        enabled = true,
-        builtIn = true,
-        models = listOf(
-            Model(
-                id = Uuid.parse("5f4d3c2b-1a0e-9d8c-7b6a-543210fedcba"),
-                modelId = "gemini-2.5-flash",
-                displayName = "Gemini 2.5 Flash",
-                inputModalities = listOf(Modality.TEXT, Modality.IMAGE),
-                outputModalities = listOf(Modality.TEXT),
-                abilities = listOf(ModelAbility.TOOL, ModelAbility.REASONING),
-            ),
-            Model(
-                id = Uuid.parse("a1b2c3d4-e5f6-7890-1234-567890abcdef"),
-                modelId = "gemini-1.5-pro",
-                displayName = "Gemini 1.5 Pro",
-                inputModalities = listOf(Modality.TEXT, Modality.IMAGE),
-                outputModalities = listOf(Modality.TEXT),
-                abilities = listOf(ModelAbility.TOOL, ModelAbility.REASONING),
-            ),
-            Model(
-                id = Uuid.parse("f1e2d3c4-b5a6-9780-1234-098765fedcba"),
-                modelId = "gemini-1.5-flash",
-                displayName = "Gemini 1.5 Flash",
-                inputModalities = listOf(Modality.TEXT, Modality.IMAGE),
-                outputModalities = listOf(Modality.TEXT),
-                abilities = listOf(ModelAbility.TOOL, ModelAbility.REASONING),
-            )
-        )
-    ),
     ProviderSetting.OpenAI(
         id = Uuid.parse("d5734028-d39b-4d41-9841-fd648d65440e"),
         name = "OpenRouter",

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
@@ -3,39 +3,29 @@ package me.rerere.rikkahub.ui.pages.setting
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.widget.Toast
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import me.rerere.rikkahub.ui.components.ui.HapticSwitch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
@@ -47,8 +37,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
@@ -82,11 +70,11 @@ import me.rerere.rikkahub.Screen
 import me.rerere.rikkahub.data.datastore.isNotConfigured
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.nav.OneUITopAppBar
-import me.rerere.rikkahub.ui.components.ui.Select
 import me.rerere.rikkahub.ui.context.LocalNavController
 import me.rerere.rikkahub.ui.hooks.HapticPattern
-import me.rerere.rikkahub.ui.hooks.rememberColorMode
 import me.rerere.rikkahub.ui.hooks.rememberPremiumHaptics
+import me.rerere.rikkahub.ui.components.ui.Select
+import me.rerere.rikkahub.ui.hooks.rememberColorMode
 import me.rerere.rikkahub.ui.theme.ColorMode
 import me.rerere.rikkahub.utils.countChatFiles
 import me.rerere.rikkahub.utils.openUrl
@@ -310,40 +298,42 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
 @Composable
 private fun ProviderConfigWarningCard(navController: NavHostController) {
     Card(
-        modifier = Modifier.padding(8.dp),
-        shape = me.rerere.rikkahub.ui.theme.AppShapes.CardMedium,
+        onClick = { navController.navigate(Screen.SettingProvider) },
+        shape = me.rerere.rikkahub.ui.theme.AppShapes.CardLarge,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.errorContainer
-        )
+        ),
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
     ) {
-        Column(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(8.dp),
-            horizontalAlignment = Alignment.End
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            ListItem(
-                headlineContent = {
-                    Text(stringResource(R.string.setting_page_config_api_title))
-                },
-                supportingContent = {
-                    Text(stringResource(R.string.setting_page_config_api_desc))
-                },
-                leadingContent = {
-                    Icon(Icons.Rounded.Warning, null)
-                },
-                colors = ListItemDefaults.colors(
-                    containerColor = Color.Transparent
-                )
+            Icon(
+                imageVector = Icons.Rounded.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer
             )
-
-            TextButton(
-                onClick = {
-                    navController.navigate(Screen.SettingProvider)
-                }
-            ) {
-                Text(stringResource(R.string.setting_page_config))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.setting_page_config_api_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer
+                )
+                Text(
+                    text = stringResource(R.string.setting_page_config_api_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.8f)
+                )
             }
+            Icon(
+                imageVector = Icons.Rounded.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer
+            )
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Make the main Settings "no models set up" warning visually consistent with the existing update banner while preserving strong warning semantics. 
- Ensure first-run defaults match the requested setup: only OpenRouter provider present and no preselected models.

### Description
- Restyled the provider warning card in `SettingPage.kt` to match the UpdateAvailableBanner layout by using `AppShapes.CardLarge`, a full-card click target (`onClick`), a row with icon / title+desc / chevron, and `errorContainer` / `onErrorContainer` colors. The banner is still shown only when `settings.isNotConfigured()` is true. (modified: `app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt`)
- Simplified bootstrap defaults so `DEFAULT_PROVIDERS` contains only the OpenRouter provider (no other built-in providers or default models are included). (modified: `app/src/main/java/me/rerere/rikkahub/data/datastore/DefaultProviders.kt`)
- Cleaned up related imports and minor layout paddings so the new banner visually matches the update banner pattern.

### Testing
- Attempted to compile the app with `./gradlew :app:compileDebugKotlin`, which failed in this environment because the Android SDK location is not configured (missing `ANDROID_HOME` / `sdk.dir`), so build-time validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989b823ae108324bceef0d6100bfd56)