### PR TITLE
fix: prevent provider API key regressions from debounced edits and add save indicator

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "lastchat.rikkafork.cocolal"
         minSdk = 31
         targetSdk = 36
-        versionCode = 25
-        versionName = "1.3.4"
+        versionCode = 26
+        versionName = "1.3.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -310,6 +310,7 @@ class SettingsStore(
         dataStore.edit { preferences ->
             preferences[PROVIDERS] = JsonInstant.encodeToString(settings.providers)
             preferences[WEBDAV_CONFIG] = JsonInstant.encodeToString(settings.webDavConfig)
+            preferences[TTS_PROVIDERS] = JsonInstant.encodeToString(settings.ttsProviders)
         }
     }
 
@@ -343,7 +344,7 @@ class SettingsStore(
         // Migrate secrets from plaintext to SecureStore if needed
         val migratedSettings = secretKeyManager.migrateSecretsFromSettings(settingsToSave)
         
-        settingsFlow.value = migratedSettings
+        settingsFlow.value = secretKeyManager.populateSecretsForExport(migratedSettings)
         dataStore.edit { preferences ->
             preferences[DYNAMIC_COLOR] = settingsToSave.dynamicColor
             preferences[THEME_ID] = settingsToSave.themeId
@@ -380,7 +381,7 @@ class SettingsStore(
 
             preferences[MCP_SERVERS] = JsonInstant.encodeToString(settingsToSave.mcpServers)
             preferences[WEBDAV_CONFIG] = JsonInstant.encodeToString(migratedSettings.webDavConfig)
-            preferences[TTS_PROVIDERS] = JsonInstant.encodeToString(settingsToSave.ttsProviders)
+            preferences[TTS_PROVIDERS] = JsonInstant.encodeToString(migratedSettings.ttsProviders)
             settingsToSave.selectedTTSProviderId?.let {
                 preferences[SELECTED_TTS_PROVIDER] = it.toString()
             } ?: preferences.remove(SELECTED_TTS_PROVIDER)

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/SecureStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/SecureStore.kt
@@ -38,7 +38,10 @@ class SecureStore(context: Context) {
      * @param value The secret value to encrypt and store
      */
     fun putSecret(key: String, value: String) {
-        encryptedPrefs.edit().putString(key, value).apply()
+        val success = encryptedPrefs.edit().putString(key, value).commit()
+        if (!success) {
+            Log.e(TAG, "Failed to store secret for key: $key")
+        }
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "Stored secret for key: $key")
         }
@@ -58,7 +61,10 @@ class SecureStore(context: Context) {
      * @param key The identifier to remove
      */
     fun removeSecret(key: String) {
-        encryptedPrefs.edit().remove(key).apply()
+        val success = encryptedPrefs.edit().remove(key).commit()
+        if (!success) {
+            Log.e(TAG, "Failed to remove secret for key: $key")
+        }
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "Removed secret for key: $key")
         }
@@ -102,7 +108,10 @@ class SecureStore(context: Context) {
      * Use with caution - typically only for debugging or factory reset.
      */
     fun clearAll() {
-        encryptedPrefs.edit().clear().apply()
+        val success = encryptedPrefs.edit().clear().commit()
+        if (!success) {
+            Log.e(TAG, "Failed to clear encrypted secrets")
+        }
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "Cleared all secrets")
         }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
@@ -81,6 +81,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -168,6 +170,8 @@ fun SettingProviderDetailPage(id: Uuid, vm: SettingVM = koinViewModel()) {
     val scope = rememberCoroutineScope()
     val toaster = LocalToaster.current
     val context = LocalContext.current
+    var savingResetJob by remember { mutableStateOf<Job?>(null) }
+    var isSaving by remember { mutableStateOf(false) }
 
     val onEdit = { newProvider: ProviderSetting ->
         val newSettings = settings.copy(
@@ -179,7 +183,13 @@ fun SettingProviderDetailPage(id: Uuid, vm: SettingVM = koinViewModel()) {
                 }
             }
         )
+        isSaving = true
+        savingResetJob?.cancel()
         vm.updateSettings(newSettings)
+        savingResetJob = scope.launch {
+            delay(600)
+            isSaving = false
+        }
     }
     val onDelete = {
         val newSettings = settings.copy(
@@ -355,7 +365,8 @@ fun SettingProviderDetailPage(id: Uuid, vm: SettingVM = koinViewModel()) {
                                 )
                                 vm.updateSettings(newSettings)
                             },
-                            contentPadding = contentPadding
+                            contentPadding = contentPadding,
+                            isSaving = isSaving
                         )
                     }
 
@@ -386,7 +397,8 @@ private fun SettingProviderConfigPage(
     providerTags: List<DataTag>,
     onEdit: (ProviderSetting) -> Unit,
     onUpdateTags: (ProviderSetting, List<DataTag>) -> Unit,
-    contentPadding: PaddingValues = PaddingValues(0.dp)
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    isSaving: Boolean
 ) {
     var internalProvider by remember(provider) { mutableStateOf(provider) }
     val scope = rememberCoroutineScope()
@@ -410,6 +422,7 @@ private fun SettingProviderConfigPage(
                 ProviderConfigure(
                     provider = internalProvider,
                     modifier = Modifier.padding(16.dp),
+                    showSavingIndicator = isSaving,
                     onEdit = {
                         internalProvider = it
                         // Auto-save immediately

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/ProviderConfigure.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/ProviderConfigure.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -49,6 +50,7 @@ import kotlin.reflect.KClass
 fun ProviderConfigure(
     provider: ProviderSetting,
     modifier: Modifier = Modifier,
+    showSavingIndicator: Boolean = false,
     onEdit: (provider: ProviderSetting) -> Unit
 ) {
     Column(
@@ -67,6 +69,13 @@ fun ProviderConfigure(
                 },
                 modifier = Modifier.weight(1f)
             )
+            if (showSavingIndicator) {
+                Text(
+                    text = "Saving...",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
             HapticSwitch(
                 checked = provider.enabled,
                 onCheckedChange = { enabled ->
@@ -230,16 +239,28 @@ private fun ColumnScope.ProviderConfigureOpenAI(
     provider: ProviderSetting.OpenAI,
     onEdit: (provider: ProviderSetting.OpenAI) -> Unit
 ) {
+    val latestProvider by rememberUpdatedState(provider)
     val toaster = LocalToaster.current
 
     provider.description()
 
     var apiKeyVisible by remember { mutableStateOf(false) }
+    var localApiKey by remember(provider.id) { mutableStateOf(provider.apiKey) }
+    LaunchedEffect(provider.apiKey) {
+        if (provider.apiKey != localApiKey) {
+            localApiKey = provider.apiKey
+        }
+    }
+    LaunchedEffect(localApiKey) {
+        delay(300)
+        val latest = latestProvider
+        if (localApiKey != latest.apiKey) {
+            onEdit(latest.copy(apiKey = localApiKey.trim()))
+        }
+    }
     OutlinedTextField(
-        value = provider.apiKey,
-        onValueChange = {
-            onEdit(provider.copy(apiKey = it.trim()))
-        },
+        value = localApiKey,
+        onValueChange = { localApiKey = it },
         label = {
             Text(stringResource(id = R.string.setting_provider_page_api_key))
         },
@@ -271,8 +292,9 @@ private fun ColumnScope.ProviderConfigureOpenAI(
     // Debounce commits to parent
     LaunchedEffect(localBaseUrl) {
         delay(300)
-        if (localBaseUrl != provider.baseUrl) {
-            onEdit(provider.copy(baseUrl = localBaseUrl.trim()))
+        val latest = latestProvider
+        if (localBaseUrl != latest.baseUrl) {
+            onEdit(latest.copy(baseUrl = localBaseUrl.trim()))
         }
     }
 
@@ -296,8 +318,9 @@ private fun ColumnScope.ProviderConfigureOpenAI(
         
         LaunchedEffect(localPath) {
             delay(300)
-            if (localPath != provider.chatCompletionsPath) {
-                onEdit(provider.copy(chatCompletionsPath = localPath.trim()))
+            val latest = latestProvider
+            if (localPath != latest.chatCompletionsPath) {
+                onEdit(latest.copy(chatCompletionsPath = localPath.trim()))
             }
         }
 
@@ -338,14 +361,26 @@ private fun ColumnScope.ProviderConfigureClaude(
     provider: ProviderSetting.Claude,
     onEdit: (provider: ProviderSetting.Claude) -> Unit
 ) {
+    val latestProvider by rememberUpdatedState(provider)
     provider.description()
 
     var apiKeyVisible by remember { mutableStateOf(false) }
+    var localApiKey by remember(provider.id) { mutableStateOf(provider.apiKey) }
+    LaunchedEffect(provider.apiKey) {
+        if (provider.apiKey != localApiKey) {
+            localApiKey = provider.apiKey
+        }
+    }
+    LaunchedEffect(localApiKey) {
+        delay(300)
+        val latest = latestProvider
+        if (localApiKey != latest.apiKey) {
+            onEdit(latest.copy(apiKey = localApiKey.trim()))
+        }
+    }
     OutlinedTextField(
-        value = provider.apiKey,
-        onValueChange = {
-            onEdit(provider.copy(apiKey = it.trim()))
-        },
+        value = localApiKey,
+        onValueChange = { localApiKey = it },
         label = {
             Text(stringResource(id = R.string.setting_provider_page_api_key))
         },
@@ -375,8 +410,9 @@ private fun ColumnScope.ProviderConfigureClaude(
     
     LaunchedEffect(localBaseUrl) {
         delay(300)
-        if (localBaseUrl != provider.baseUrl) {
-            onEdit(provider.copy(baseUrl = localBaseUrl.trim()))
+        val latest = latestProvider
+        if (localBaseUrl != latest.baseUrl) {
+            onEdit(latest.copy(baseUrl = localBaseUrl.trim()))
         }
     }
 
@@ -395,6 +431,7 @@ private fun ColumnScope.ProviderConfigureGoogle(
     provider: ProviderSetting.Google,
     onEdit: (provider: ProviderSetting.Google) -> Unit
 ) {
+    val latestProvider by rememberUpdatedState(provider)
     provider.description()
 
     Row(
@@ -411,11 +448,22 @@ private fun ColumnScope.ProviderConfigureGoogle(
 
     if (!provider.vertexAI) {
         var apiKeyVisible by remember { mutableStateOf(false) }
+        var localApiKey by remember(provider.id) { mutableStateOf(provider.apiKey) }
+        LaunchedEffect(provider.apiKey) {
+            if (provider.apiKey != localApiKey) {
+                localApiKey = provider.apiKey
+            }
+        }
+        LaunchedEffect(localApiKey) {
+            delay(300)
+            val latest = latestProvider
+            if (localApiKey != latest.apiKey) {
+                onEdit(latest.copy(apiKey = localApiKey.trim()))
+            }
+        }
         OutlinedTextField(
-            value = provider.apiKey,
-            onValueChange = {
-                onEdit(provider.copy(apiKey = it.trim()))
-            },
+            value = localApiKey,
+            onValueChange = { localApiKey = it },
             label = {
                 Text(stringResource(id = R.string.setting_provider_page_api_key))
             },
@@ -445,8 +493,9 @@ private fun ColumnScope.ProviderConfigureGoogle(
         
         LaunchedEffect(localBaseUrl) {
             delay(300)
-            if (localBaseUrl != provider.baseUrl) {
-                onEdit(provider.copy(baseUrl = localBaseUrl.trim()))
+            val latest = latestProvider
+            if (localBaseUrl != latest.baseUrl) {
+                onEdit(latest.copy(baseUrl = localBaseUrl.trim()))
             }
         }
 
@@ -488,19 +537,23 @@ private fun ColumnScope.ProviderConfigureGoogle(
         // Debounce commits
         LaunchedEffect(localEmail) {
             delay(300)
-            if (localEmail != provider.serviceAccountEmail) onEdit(provider.copy(serviceAccountEmail = localEmail.trim()))
+            val latest = latestProvider
+            if (localEmail != latest.serviceAccountEmail) onEdit(latest.copy(serviceAccountEmail = localEmail.trim()))
         }
         LaunchedEffect(localPrivateKey) {
             delay(300)
-            if (localPrivateKey != provider.privateKey) onEdit(provider.copy(privateKey = localPrivateKey.trim()))
+            val latest = latestProvider
+            if (localPrivateKey != latest.privateKey) onEdit(latest.copy(privateKey = localPrivateKey.trim()))
         }
         LaunchedEffect(localLocation) {
             delay(300)
-            if (localLocation != provider.location) onEdit(provider.copy(location = localLocation.trim()))
+            val latest = latestProvider
+            if (localLocation != latest.location) onEdit(latest.copy(location = localLocation.trim()))
         }
         LaunchedEffect(localProjectId) {
             delay(300)
-            if (localProjectId != provider.projectId) onEdit(provider.copy(projectId = localProjectId.trim()))
+            val latest = latestProvider
+            if (localProjectId != latest.projectId) onEdit(latest.copy(projectId = localProjectId.trim()))
         }
 
         OutlinedTextField(


### PR DESCRIPTION
### Motivation
- Users reported API keys being unexpectedly cleared and the API key input being laggy after introducing debounced/migrated secret handling, indicating a race where delayed saves could write back stale provider snapshots.
- Improve UX visibility for pages that autosave debounced input by showing a short-lived `Saving...` indicator so users know changes are being persisted.

### Description
- Replace direct delayed writes that used the captured `provider` snapshot with `rememberUpdatedState(provider)` and apply debounced commits against the latest provider snapshot to prevent stale overwrites for API keys, base URLs, paths, and Vertex fields in `ProviderConfigure`.
- Debounce the API key input similarly to the base URL/path fields by introducing per-field local state (`localApiKey`, `localBaseUrl`, `localPath`, etc.) and `LaunchedEffect`-based commit delays to reduce typing lag and avoid per-keystroke writes.
- Add a `showSavingIndicator` parameter to `ProviderConfigure` and a short `isSaving` window in `SettingProviderDetailPage` so the UI displays `Saving...` to the left of the enable/disable toggle while edits are being persisted.
- Bump app version to `1.3.5` (`versionCode = 26`) to reflect the fix.

### Testing
- Attempted `./gradlew :app:compileDebugKotlin` to validate Kotlin compilation, which failed in this environment due to missing Android SDK configuration (`ANDROID_HOME` / `local.properties`), so a local compile could not be completed here (failed).
- Ran repository inspections and grep searches (`rg`) and reviewed diffs to validate the changed code paths and ensure debounced commits now reference the latest provider snapshot (succeeded).
- Performed a code-path audit of provider edit -> settings persist -> secret migration flow to ensure the migration logic in `SecretKeyManager` and `PreferencesStore` remains compatible with the new debounced commit behavior (review completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a21f71e0c8324b0a3395550309f9b)