### PR TITLE
feat: refresh chat top bar and add drawer title editing

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -197,6 +197,9 @@ fun ChatDrawerContent(
                 onRegenerateTitle = {
                     vm.generateTitle(it, true)
                 },
+                onEditTitle = { conversation, title ->
+                    vm.updateConversationTitle(conversation, title)
+                },
                 onConsolidate = {
                     vm.consolidateConversation(it)
                 },

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -333,9 +333,6 @@ private fun ChatPageContent(
                         onClickMenu = {
                             previewMode = !previewMode
                         },
-                        onUpdateTitle = {
-                            vm.updateTitle(it)
-                        },
                         onUpdateSettings = { newSettings ->
                             vm.updateSettings(newSettings)
                         },
@@ -876,116 +873,118 @@ private fun TopBar(
     isTemporaryChat: Boolean,
     onClickMenu: () -> Unit,
     onNewChat: () -> Unit,
-    onUpdateTitle: (String) -> Unit,
     onUpdateSettings: (Settings) -> Unit,
     onToggleTemporaryChat: () -> Unit
 ) {
     val scope = rememberCoroutineScope()
-    val toaster = LocalToaster.current
-    val titleState = useEditState<String> {
-        onUpdateTitle(it)
-    }
-    
+    val topContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.92f)
+    val buttonShape = RoundedCornerShape(999.dp)
+
     // State for assistant picker - must be at function level for proper recomposition
     var showAssistantPicker by remember { mutableStateOf(false) }
     val currentAssistant = settings.getCurrentAssistant()
+    val isEmpty = !conversation.messageNodes.any { it.role == me.rerere.ai.core.MessageRole.USER }
 
-    TopAppBar(
-        colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
-        navigationIcon = {
+    Box(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .height(120.dp)
+                .background(
+                    brush = androidx.compose.ui.graphics.Brush.verticalGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.background.copy(alpha = 0.95f),
+                            Color.Transparent
+                        )
+                    )
+                )
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             if (!bigScreen) {
-                IconButton(
+                Surface(
                     onClick = {
                         scope.launch { drawerState.open() }
-                    }
+                    },
+                    shape = buttonShape,
+                    color = topContainerColor
                 ) {
-                    Icon(Icons.Rounded.Menu, "Messages")
-                }
-            }
-        },
-        title = {
-            val editTitleWarning = stringResource(R.string.chat_page_edit_title_warning)
-            
-            // Crossfade between normal title and "Temporary Chat"
-            androidx.compose.animation.AnimatedContent(
-                targetState = isTemporaryChat,
-                transitionSpec = {
-                    androidx.compose.animation.fadeIn(
-                        animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 400f)
-                    ) togetherWith androidx.compose.animation.fadeOut(
-                        animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 400f)
-                    )
-                },
-                label = "title_crossfade"
-            ) { isTempChat ->
-                if (isTempChat) {
-                    Text(
-                        text = stringResource(R.string.temporary_chat_title),
-                        maxLines = 1,
-                        style = MaterialTheme.typography.titleMedium,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                } else {
-                    Surface(
-                        onClick = {
-                            if (conversation.messageNodes.isNotEmpty()) {
-                                titleState.open(conversation.title)
-                            } else {
-                                toaster.show(editTitleWarning, type = ToastType.Warning)
-                            }
-                        },
-                        color = Color.Transparent,
+                    Box(
+                        modifier = Modifier.size(52.dp),
+                        contentAlignment = Alignment.Center
                     ) {
-                        Text(
-                            text = conversation.title.ifBlank { stringResource(R.string.chat_page_new_chat) },
-                            maxLines = 1,
-                            style = MaterialTheme.typography.titleMedium,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                        Icon(Icons.Rounded.Menu, "Messages")
                     }
                 }
             }
-        },
-        actions = {
-            // Check if chat is "empty" (no user-sent messages, ignoring preset messages)
-            val isEmpty = !conversation.messageNodes.any { it.role == me.rerere.ai.core.MessageRole.USER }
-            
-            // Fluid transition between assistant icon and search/new icons
-            androidx.compose.animation.AnimatedContent(
-                targetState = isEmpty to isTemporaryChat,
-                transitionSpec = {
-                    (androidx.compose.animation.fadeIn(
-                        animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 400f)
-                    ) + androidx.compose.animation.scaleIn(
-                        initialScale = 0.85f,
-                        animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 400f)
-                    )) togetherWith (androidx.compose.animation.fadeOut(
-                        animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 400f)
-                    ) + androidx.compose.animation.scaleOut(
-                        targetScale = 0.85f,
-                        animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 400f)
-                    ))
-                },
-                label = "topbar_actions"
-            ) { (isEmptyState, isTempChat) ->
-                // Check if header mode shows an avatar (to hide top-right avatar)
-                val hasPresetMessages = currentAssistant.presetMessages.isNotEmpty()
-                val effectiveDisplay = settings.getEffectiveDisplaySetting(currentAssistant)
-                val headerShowsAvatar = effectiveDisplay.newChatShowAvatar && (
-                    effectiveDisplay.newChatHeaderStyle == me.rerere.rikkahub.data.datastore.NewChatHeaderStyle.BIG_ICON ||
-                    effectiveDisplay.newChatHeaderStyle == me.rerere.rikkahub.data.datastore.NewChatHeaderStyle.GREETING
-                )
-                val hideTopRightAvatar = !hasPresetMessages && headerShowsAvatar
-                
-                when {
-                    // Empty normal chat: show temp toggle + assistant (unless big icon mode)
-                    isEmptyState && !isTempChat -> {
-                        Row {
-                            IconButton(onClick = { onToggleTemporaryChat() }) {
-                                Icon(Icons.Rounded.HistoryToggleOff, "Temporary Chat")
+
+            androidx.compose.foundation.layout.Spacer(Modifier.weight(1f))
+
+            Surface(
+                shape = buttonShape,
+                color = topContainerColor
+            ) {
+                androidx.compose.animation.AnimatedContent(
+                    targetState = isEmpty to isTemporaryChat,
+                    transitionSpec = {
+                        (androidx.compose.animation.fadeIn(
+                            animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 300f)
+                        ) + androidx.compose.animation.scaleIn(
+                            initialScale = 0.9f,
+                            animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 300f)
+                        )) togetherWith (androidx.compose.animation.fadeOut(
+                            animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 300f)
+                        ) + androidx.compose.animation.scaleOut(
+                            targetScale = 0.9f,
+                            animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 300f)
+                        ))
+                    },
+                    label = "topbar_actions"
+                ) { (isEmptyState, isTempChat) ->
+                    val hasPresetMessages = currentAssistant.presetMessages.isNotEmpty()
+                    val effectiveDisplay = settings.getEffectiveDisplaySetting(currentAssistant)
+                    val headerShowsAvatar = effectiveDisplay.newChatShowAvatar && (
+                        effectiveDisplay.newChatHeaderStyle == me.rerere.rikkahub.data.datastore.NewChatHeaderStyle.BIG_ICON ||
+                            effectiveDisplay.newChatHeaderStyle == me.rerere.rikkahub.data.datastore.NewChatHeaderStyle.GREETING
+                        )
+                    val hideTopRightAvatar = !hasPresetMessages && headerShowsAvatar
+
+                    Row(
+                        modifier = Modifier.padding(horizontal = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        when {
+                            isEmptyState && !isTempChat -> {
+                                IconButton(onClick = { onToggleTemporaryChat() }) {
+                                    Icon(Icons.Rounded.HistoryToggleOff, "Temporary Chat")
+                                }
+                                if (!hideTopRightAvatar) {
+                                    Box(
+                                        modifier = Modifier.size(48.dp),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        me.rerere.rikkahub.ui.components.ui.UIAvatar(
+                                            name = currentAssistant.name.ifBlank { "Character" },
+                                            value = currentAssistant.avatar,
+                                            modifier = Modifier.size(30.dp),
+                                            onClick = { showAssistantPicker = true }
+                                        )
+                                    }
+                                }
                             }
-                            // Only show avatar if header doesn't already show one
-                            if (!hideTopRightAvatar) {
+
+                            isEmptyState && isTempChat -> {
+                                IconButton(onClick = { onToggleTemporaryChat() }) {
+                                    Icon(Icons.Rounded.History, "Make Normal Chat")
+                                }
                                 Box(
                                     modifier = Modifier.size(48.dp),
                                     contentAlignment = Alignment.Center
@@ -993,47 +992,26 @@ private fun TopBar(
                                     me.rerere.rikkahub.ui.components.ui.UIAvatar(
                                         name = currentAssistant.name.ifBlank { "Character" },
                                         value = currentAssistant.avatar,
-                                        modifier = Modifier.size(32.dp),
+                                        modifier = Modifier.size(30.dp),
                                         onClick = { showAssistantPicker = true }
                                     )
                                 }
                             }
-                        }
-                    }
-                    // Empty temporary chat: show history (toggle back) + assistant
-                    isEmptyState && isTempChat -> {
-                        Row {
-                            IconButton(onClick = { onToggleTemporaryChat() }) {
-                                Icon(Icons.Rounded.History, "Make Normal Chat")
-                            }
-                            Box(
-                                modifier = Modifier.size(48.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                me.rerere.rikkahub.ui.components.ui.UIAvatar(
-                                    name = currentAssistant.name.ifBlank { "Character" },
-                                    value = currentAssistant.avatar,
-                                    modifier = Modifier.size(32.dp),
-                                    onClick = { showAssistantPicker = true }
-                                )
-                            }
-                        }
-                    }
-                    // Non-empty (either temporary or normal): show search + new chat
-                    else -> {
-                        Row {
-                            IconButton(onClick = { onClickMenu() }) {
-                                Icon(if (previewMode) Icons.Rounded.Close else Icons.Rounded.Search, "Chat Options")
-                            }
-                            IconButton(onClick = { onNewChat() }) {
-                                Icon(Icons.Rounded.AddCircle, "New Message")
+
+                            else -> {
+                                IconButton(onClick = { onClickMenu() }) {
+                                    Icon(if (previewMode) Icons.Rounded.Close else Icons.Rounded.Search, "Chat Options")
+                                }
+                                IconButton(onClick = { onNewChat() }) {
+                                    Icon(Icons.Rounded.AddCircle, "New Message")
+                                }
                             }
                         }
                     }
                 }
             }
-        },
-    )
+        }
+    }
     
     // Assistant picker sheet - outside TopAppBar for proper state handling
     if (showAssistantPicker) {
@@ -1046,42 +1024,6 @@ private fun TopBar(
                 showAssistantPicker = false
             },
             onDismiss = { showAssistantPicker = false }
-        )
-    }
-    titleState.EditStateContent { title, onUpdate ->
-        AlertDialog(
-            onDismissRequest = {
-                titleState.dismiss()
-            },
-            title = {
-                Text(stringResource(R.string.chat_page_edit_title))
-            },
-            text = {
-                OutlinedTextField(
-                    value = title,
-                    onValueChange = onUpdate,
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        titleState.confirm()
-                    }
-                ) {
-                    Text(stringResource(R.string.chat_page_save))
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = {
-                        titleState.dismiss()
-                    }
-                ) {
-                    Text(stringResource(R.string.chat_page_cancel))
-                }
-            }
         )
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
@@ -723,6 +723,12 @@ class ChatVM(
         }
     }
 
+    fun updateConversationTitle(conversation: Conversation, title: String) {
+        viewModelScope.launch {
+            conversationRepo.updateConversation(conversation.copy(title = title))
+        }
+    }
+
     fun generateTitle(conversation: Conversation, force: Boolean = false) {
         viewModelScope.launch {
             val conversationFull = conversationRepo.getConversationById(conversation.id) ?: return@launch

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationList.kt
@@ -29,11 +29,14 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.surfaceColorAtElevation
@@ -63,6 +66,7 @@ import androidx.paging.compose.itemKey
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.PushPin
+import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Memory
@@ -105,6 +109,7 @@ fun ColumnScope.ConversationList(
     onClick: (Conversation) -> Unit = {},
     onDelete: (Conversation) -> Unit = {},
     onRegenerateTitle: (Conversation) -> Unit = {},
+    onEditTitle: (Conversation, String) -> Unit = { _, _ -> },
     onConsolidate: (Conversation) -> Unit = {},
     onPin: (Conversation) -> Unit = {},
     showUnconsolidatedDot: Boolean = false,
@@ -231,6 +236,7 @@ fun ColumnScope.ConversationList(
                             onClick = onClick,
                             onDelete = onDelete,
                             onRegenerateTitle = onRegenerateTitle,
+                            onEditTitle = onEditTitle,
                             onConsolidate = onConsolidate,
                             onPin = onPin,
                             showUnconsolidatedDot = showUnconsolidatedDot,
@@ -348,6 +354,7 @@ private fun ConversationItem(
     modifier: Modifier = Modifier,
     onDelete: (Conversation) -> Unit = {},
     onRegenerateTitle: (Conversation) -> Unit = {},
+    onEditTitle: (Conversation, String) -> Unit = { _, _ -> },
     onConsolidate: (Conversation) -> Unit = {},
     onPin: (Conversation) -> Unit = {},
     showUnconsolidatedDot: Boolean = false,
@@ -395,6 +402,8 @@ private fun ConversationItem(
     var showDropdownMenu by remember {
         mutableStateOf(false)
     }
+    var showEditTitleDialog by remember { mutableStateOf(false) }
+    var editedTitle by remember(conversation.id) { mutableStateOf(conversation.title) }
     Box(
         modifier = modifier
             .graphicsLayer {
@@ -488,6 +497,21 @@ private fun ConversationItem(
 
                 DropdownMenuItem(
                     text = {
+                        Text(stringResource(R.string.chat_page_edit_title))
+                    },
+                    onClick = {
+                        haptics.perform(HapticPattern.Pop)
+                        editedTitle = conversation.title
+                        showEditTitleDialog = true
+                        showDropdownMenu = false
+                    },
+                    leadingIcon = {
+                        Icon(Icons.Rounded.Edit, null)
+                    }
+                )
+
+                DropdownMenuItem(
+                    text = {
                         Text(stringResource(id = R.string.chat_page_regenerate_title))
                     },
                     onClick = {
@@ -527,6 +551,35 @@ private fun ConversationItem(
                     },
                     leadingIcon = {
                         Icon(Icons.Rounded.Delete, null)
+                    }
+                )
+            }
+
+            if (showEditTitleDialog) {
+                AlertDialog(
+                    onDismissRequest = { showEditTitleDialog = false },
+                    title = { Text(stringResource(R.string.chat_page_edit_title)) },
+                    text = {
+                        OutlinedTextField(
+                            value = editedTitle,
+                            onValueChange = { editedTitle = it },
+                            singleLine = true
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(
+                            onClick = {
+                                onEditTitle(conversation, editedTitle)
+                                showEditTitleDialog = false
+                            }
+                        ) {
+                            Text(stringResource(R.string.chat_page_save))
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showEditTitleDialog = false }) {
+                            Text(stringResource(R.string.chat_page_cancel))
+                        }
                     }
                 )
             }


### PR DESCRIPTION
## Summary
- redesigned the chat top bar to a pill-style layout inspired by the reference while preserving existing LastChat actions/icons
- removed the in-bar chat title display and added a top gradient fade to mirror the floating fade treatment
- kept state transitions smooth with spring-based AnimatedContent for all top-bar action-state changes
- added a new **Edit title** action in the conversation long-press menu, placed directly under **Pin chat**
- wired title editing from the drawer menu through `ConversationList -> ChatDrawer -> ChatVM`

## Files changed
- `app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt`
- `app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationList.kt`
- `app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt`
- `app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt`

## Validation
- attempted Kotlin compilation to validate changes, but local Android SDK is not configured in this environment (`SDK location not found`)
- attempted to capture a screenshot via browser tooling, but the project is an Android Compose app and no web endpoint was available (`ERR_EMPTY_RESPONSE` on localhost)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e54f36b8c832a98da34dba6937b3c)