### PR TITLE
fix: replace nav tween transitions with spring animations

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
@@ -8,8 +8,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.SharedTransitionLayout
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
@@ -413,23 +412,23 @@ class RouteActivity : ComponentActivity() {
                     navController = navBackStack,
                     enterTransition = { 
                         slideInHorizontally(
-                            animationSpec = tween(200, easing = FastOutSlowInEasing)
-                        ) { it / 2 } + fadeIn(animationSpec = tween(150))
+                            animationSpec = spring(dampingRatio = 0.5f, stiffness = 400f)
+                        ) { it / 2 } + fadeIn(animationSpec = spring(dampingRatio = 0.5f, stiffness = 400f))
                     },
                     exitTransition = { 
                         slideOutHorizontally(
-                            animationSpec = tween(200, easing = FastOutSlowInEasing)
-                        ) { -it / 4 } + fadeOut(animationSpec = tween(100))
+                            animationSpec = spring(dampingRatio = 0.5f, stiffness = 400f)
+                        ) { -it / 4 } + fadeOut(animationSpec = spring(dampingRatio = 0.5f, stiffness = 400f))
                     },
                     popEnterTransition = {
                         slideInHorizontally(
-                            animationSpec = tween(200, easing = FastOutSlowInEasing)
-                        ) { -it / 4 } + fadeIn(animationSpec = tween(150))
+                            animationSpec = spring(dampingRatio = 0.5f, stiffness = 400f)
+                        ) { -it / 4 } + fadeIn(animationSpec = spring(dampingRatio = 0.5f, stiffness = 400f))
                     },
                     popExitTransition = {
                         slideOutHorizontally(
-                            animationSpec = tween(200, easing = FastOutSlowInEasing)
-                        ) { it / 2 } + fadeOut(animationSpec = tween(100))
+                            animationSpec = spring(dampingRatio = 0.5f, stiffness = 400f)
+                        ) { it / 2 } + fadeOut(animationSpec = spring(dampingRatio = 0.5f, stiffness = 400f))
                     }
                 ) {
                     composable<Screen.Chat>(


### PR DESCRIPTION
### Motivation
- Replace linear/tween-based navigation motion with physics-based springs to comply with the project UI/UX rule forbidding `tween`/linear animations and to improve motion coherence with Material You Expressive guidelines.
- Reduce animation API inconsistencies across screens by using the established spring spec `spring(dampingRatio = 0.5f, stiffness = 400f)`.

### Description
- Replaced `tween(..., easing = FastOutSlowInEasing)` usages for `slideInHorizontally`, `slideOutHorizontally`, `fadeIn`, and `fadeOut` with `spring(dampingRatio = 0.5f, stiffness = 400f)` in `NavHost` transitions.
- Removed now-unused tween/easing imports and added `spring` import usage in `app/src/main/java/me/rerere/rikkahub/RouteActivity.kt`.
- The only modified file is `app/src/main/java/me/rerere/rikkahub/RouteActivity.kt` and route enter/exit/pop-enter/pop-exit transitions are updated to use spring specs.

### Testing
- Ran a static search to verify no `tween(...)` calls remain in `RouteActivity`, which succeeded.
- Attempted `./gradlew :app:compileDebugKotlin --warning-mode all`, but the build was blocked by the environment due to missing Android SDK location (no `ANDROID_HOME` or `local.properties` `sdk.dir`), so a full compile could not complete.
- Performed a focused runtime/static check on the modified file to confirm imports and usages were updated, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e5bcc3fe4832ab4f538b9830992ad)