### PR TITLE
fix(ui): restore Compose-compatible top-bar insets and adjust model selector

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt
@@ -2,6 +2,7 @@ package me.rerere.rikkahub.ui.components.ai
 
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
@@ -27,6 +28,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import androidx.compose.material.icons.Icons
@@ -164,17 +166,18 @@ fun ModelSelector(
             }
         }
     } else {
-        IconButton(
-            onClick = {
-                popup = true
-            },
+        Box(
+            modifier = modifier
+                .clip(CircleShape)
+                .clickable { popup = true },
+            contentAlignment = Alignment.Center
         ) {
             if (model != null) {
                 val provider = model.findProvider(providers = providers)
                 ModelIcon(
                     model = model,
                     provider = provider,
-                    modifier = Modifier.size(36.dp),
+                    modifier = Modifier.fillMaxSize(),
                     color = Color.Transparent,
                 )
             } else {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -342,11 +342,10 @@ private fun ChatPageContent(
                 // Removed bottomBar to allow floating input
                 containerColor = Color.Transparent,
                 contentWindowInsets = WindowInsets(0.dp)
-            ) { innerPadding ->
+            ) { _ ->
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(innerPadding)
                 ) {
                     ChatList(
                         innerPadding = PaddingValues(top = 8.dp, bottom = 140.dp),
@@ -888,12 +887,12 @@ private fun TopBar(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .statusBarsPadding()
     ) {
         Box(
             modifier = Modifier
                 .align(Alignment.TopCenter)
                 .fillMaxWidth()
+                .statusBarsPadding()
                 .height(120.dp)
                 .background(
                     brush = androidx.compose.ui.graphics.Brush.verticalGradient(
@@ -950,7 +949,12 @@ private fun TopBar(
                         ) + androidx.compose.animation.scaleOut(
                             targetScale = 0.9f,
                             animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 300f)
-                        ))
+                        )) using androidx.compose.animation.SizeTransform(
+                            clip = false,
+                            sizeAnimationSpec = { _, _ ->
+                                androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 300f)
+                            }
+                        )
                     },
                     label = "topbar_actions"
                 ) { (isEmptyState, isTempChat) ->
@@ -961,16 +965,10 @@ private fun TopBar(
                             effectiveDisplay.newChatHeaderStyle == me.rerere.rikkahub.data.datastore.NewChatHeaderStyle.GREETING
                         )
                     val hideTopRightAvatar = !hasPresetMessages && headerShowsAvatar
-                    val actionCount = when {
-                        isEmptyState && !isTempChat && hideTopRightAvatar -> 1
-                        isEmptyState && !isTempChat -> 2
-                        isEmptyState && isTempChat -> 2
-                        else -> 2
-                    }
-                    val actionContainerPadding = if (actionCount > 1) 2.dp else 0.dp
-
                     Row(
-                        modifier = Modifier.padding(all = actionContainerPadding),
+                        modifier = Modifier
+                            .height(topPillSize)
+                            .padding(horizontal = 4.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         when {


### PR DESCRIPTION
### Motivation
- The build failed with unresolved references to `calculateBottomPadding`, `calculateTopPadding`, `asPaddingValues`, and `WindowInsets.statusBars` on some environments, so the top-bar/gradient and scaffold padding needed to be implemented using Compose APIs available in the current setup.
- The UI should keep the top fade into the status bar without pushing chat content down or relying on unavailable helper functions.
- The model selector interaction area needed a small usability tweak to make the icon clickable and preserve consistent sizing behavior.

### Description
- Removed imports and usages of `calculateBottomPadding`, `calculateTopPadding`, and `asPaddingValues` and stopped using the `innerPadding` from the `Scaffold` content lambda, keeping the chat content area full-height. 
- Replaced programmatic `WindowInsets.statusBars.asPaddingValues().calculateTopPadding()` with `Modifier.statusBarsPadding()` on the top gradient layer so the fade now extends into the status bar using available Compose APIs. 
- Adjusted `TopBar` layout to apply `statusBarsPadding()` to the correct layer and switched the gradient container to a fixed `height(120.dp)` so top content is not cut off. 
- Improved `AnimatedContent` transition by adding a non-clipping `SizeTransform` and simplified the action container padding into a fixed height and horizontal padding to stabilize layout. 
- Updated the model selector in `ModelList.kt` to use a `Box` with `Modifier.clickable` and `CircleShape` and adjusted `ModelIcon` sizing for consistent appearance.
- Committed change with message `fix: restore compose-compatible top bar inset handling`.

### Testing
- Ran the user's failing build log (`./gradlew assembleDebug`) which originally showed compile errors for unresolved inset helpers and confirmed the root issue; this run failed in the user's environment due to unresolved references (observed in provided logs).
- Executed `./gradlew :app:compileDebugKotlin` in the patch environment which failed before compilation due to a missing Android SDK configuration (`ANDROID_HOME` / `local.properties` `sdk.dir`), so a full compile could not be validated here. 
- Executed an automated Playwright screenshot attempt which failed (`ERR_EMPTY_RESPONSE`) because no web endpoint is available for the Android Compose UI in this environment, so visual verification was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7b92b5f08324b32151da92620f83)