### PR TITLE
fix(topbar): smooth transitions and consistent sizing for top-right action pill

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -939,19 +939,19 @@ private fun TopBar(
                     targetState = isEmpty to isTemporaryChat,
                     transitionSpec = {
                         (androidx.compose.animation.fadeIn(
-                            animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 300f)
+                            animationSpec = androidx.compose.animation.core.tween(durationMillis = 220)
                         ) + androidx.compose.animation.scaleIn(
                             initialScale = 0.9f,
-                            animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 300f)
+                            animationSpec = androidx.compose.animation.core.tween(durationMillis = 220)
                         )) togetherWith (androidx.compose.animation.fadeOut(
-                            animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 300f)
+                            animationSpec = androidx.compose.animation.core.tween(durationMillis = 180)
                         ) + androidx.compose.animation.scaleOut(
                             targetScale = 0.9f,
-                            animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 300f)
+                            animationSpec = androidx.compose.animation.core.tween(durationMillis = 180)
                         )) using androidx.compose.animation.SizeTransform(
                             clip = false,
                             sizeAnimationSpec = { _, _ ->
-                                androidx.compose.animation.core.spring(dampingRatio = 0.6f, stiffness = 300f)
+                                androidx.compose.animation.core.tween(durationMillis = 220)
                             }
                         )
                     },
@@ -964,21 +964,28 @@ private fun TopBar(
                             effectiveDisplay.newChatHeaderStyle == me.rerere.rikkahub.data.datastore.NewChatHeaderStyle.GREETING
                         )
                     val hideTopRightAvatar = !hasPresetMessages && headerShowsAvatar
-                    Row(
-                        modifier = Modifier
-                            .height(topPillSize)
-                            .padding(horizontal = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        when {
-                            isEmptyState && !isTempChat -> {
-                                IconButton(
-                                    onClick = { onToggleTemporaryChat() },
-                                    modifier = Modifier.size(topPillSize)
-                                ) {
-                                    Icon(Icons.Rounded.HistoryToggleOff, "Temporary Chat")
-                                }
-                                if (!hideTopRightAvatar) {
+                    when {
+                        isEmptyState && !isTempChat && hideTopRightAvatar -> {
+                            IconButton(
+                                onClick = { onToggleTemporaryChat() },
+                                modifier = Modifier.size(topPillSize)
+                            ) {
+                                Icon(Icons.Rounded.HistoryToggleOff, "Temporary Chat")
+                            }
+                        }
+
+                        else -> Row(
+                            modifier = Modifier.height(topPillSize),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            when {
+                                isEmptyState && !isTempChat -> {
+                                    IconButton(
+                                        onClick = { onToggleTemporaryChat() },
+                                        modifier = Modifier.size(topPillSize)
+                                    ) {
+                                        Icon(Icons.Rounded.HistoryToggleOff, "Temporary Chat")
+                                    }
                                     Box(
                                         modifier = Modifier.size(topPillSize),
                                         contentAlignment = Alignment.Center
@@ -991,40 +998,40 @@ private fun TopBar(
                                         )
                                     }
                                 }
-                            }
 
-                            isEmptyState && isTempChat -> {
-                                IconButton(
-                                    onClick = { onToggleTemporaryChat() },
-                                    modifier = Modifier.size(topPillSize)
-                                ) {
-                                    Icon(Icons.Rounded.History, "Make Normal Chat")
+                                isEmptyState && isTempChat -> {
+                                    IconButton(
+                                        onClick = { onToggleTemporaryChat() },
+                                        modifier = Modifier.size(topPillSize)
+                                    ) {
+                                        Icon(Icons.Rounded.History, "Make Normal Chat")
+                                    }
+                                    Box(
+                                        modifier = Modifier.size(topPillSize),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        me.rerere.rikkahub.ui.components.ui.UIAvatar(
+                                            name = currentAssistant.name.ifBlank { "Character" },
+                                            value = currentAssistant.avatar,
+                                            modifier = Modifier.size(30.dp),
+                                            onClick = { showAssistantPicker = true }
+                                        )
+                                    }
                                 }
-                                Box(
-                                    modifier = Modifier.size(topPillSize),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    me.rerere.rikkahub.ui.components.ui.UIAvatar(
-                                        name = currentAssistant.name.ifBlank { "Character" },
-                                        value = currentAssistant.avatar,
-                                        modifier = Modifier.size(30.dp),
-                                        onClick = { showAssistantPicker = true }
-                                    )
-                                }
-                            }
 
-                            else -> {
-                                IconButton(
-                                    onClick = { onClickMenu() },
-                                    modifier = Modifier.size(topPillSize)
-                                ) {
-                                    Icon(if (previewMode) Icons.Rounded.Close else Icons.Rounded.Search, "Chat Options")
-                                }
-                                IconButton(
-                                    onClick = { onNewChat() },
-                                    modifier = Modifier.size(topPillSize)
-                                ) {
-                                    Icon(Icons.Rounded.Add, "New Message")
+                                else -> {
+                                    IconButton(
+                                        onClick = { onClickMenu() },
+                                        modifier = Modifier.size(topPillSize)
+                                    ) {
+                                        Icon(if (previewMode) Icons.Rounded.Close else Icons.Rounded.Search, "Chat Options")
+                                    }
+                                    IconButton(
+                                        onClick = { onNewChat() },
+                                        modifier = Modifier.size(topPillSize)
+                                    ) {
+                                        Icon(Icons.Rounded.Add, "New Message")
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
### Motivation
- Ensure the top-right action pill in the chat top bar renders as a perfect circle when only one action is present and has balanced padding when multiple icons are present.
- Remove physics-based spring animations in favor of smoother, deterministic transitions for state changes (including new chat creation).
- Keep the pill height locked to match the minimal input bar so visual rhythm is preserved across the UI.

### Description
- Replaced spring-based `AnimatedContent` animation specs with tween-based `fadeIn`/`fadeOut`/`scaleIn`/`scaleOut` and a tween `SizeTransform` for consistent smooth transitions (`app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt`).
- Changed the top-right layout logic so the single-action case renders only a single `IconButton` sized to `topPillSize` (`48.dp`) to ensure a true circular pill and removed the extra horizontal padding used for the multi-action wrapper.
- Preserved the existing `topPillSize` (`48.dp`) so the top-right pill height remains identical to the minimal input bar.
- Adjusted multi-action layout to use a `Row` with explicit `height(topPillSize)` so icon spacing is balanced on all sides.

### Testing
- Ran `./gradlew :app:compileDebugKotlin` to validate Kotlin compilation; the build could not complete in this environment because the Android SDK location is not configured (missing `ANDROID_HOME` or `local.properties`).
- No further automated tests were executed in this environment due to the missing SDK; UI behavior should be verified on-device or in an emulator after configuring the Android SDK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eee1e9158832ab032abbb1638008e)