### PR TITLE
fix: use stable status bar inset API in ChatPage

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.getTop
+import androidx.compose.foundation.layout.calculateTopPadding
 import androidx.compose.foundation.background
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -47,7 +47,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -891,8 +890,7 @@ private fun TopBar(
     val topContainerBorder = BorderStroke(1.dp, MaterialTheme.colorScheme.background)
     val buttonShape = RoundedCornerShape(999.dp)
     val topPillSize = 48.dp
-    val density = LocalDensity.current
-    val statusBarHeight = with(density) { WindowInsets.statusBars.getTop(this).toDp() }
+    val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
     // State for assistant picker - must be at function level for proper recomposition
     var showAssistantPicker by remember { mutableStateOf(false) }
     val currentAssistant = settings.getCurrentAssistant()


### PR DESCRIPTION
### Motivation
- Replace an unresolved/unsupported status bar inset usage (`getTop`) in `ChatPage.kt` that caused release compilation errors with a stable API.

### Description
- Swap the import of `getTop` for `calculateTopPadding`, remove the now-unused `LocalDensity` usage, and compute `statusBarHeight` with `WindowInsets.statusBars.asPaddingValues().calculateTopPadding()` in `app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt`.

### Testing
- Ran `./gradlew :app:compileReleaseKotlin --stacktrace`, but the build could not proceed because the Android SDK location is not configured (error: `SDK location not found`), so a full compile validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ef6804094832498db3f7299203abb)