### PR TITLE
fix: make Firebase plugins optional when google-services.json is missing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,9 +11,23 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.google.services)
-    alias(libs.plugins.firebase.crashlytics)
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.chaquopy)
+}
+
+val hasGoogleServicesJson = sequenceOf(
+    "google-services.json",
+    "src/google-services.json",
+    "src/debug/google-services.json",
+    "src/release/google-services.json"
+).map(::file).any { it.exists() }
+
+if (hasGoogleServicesJson) {
+    apply(plugin = "com.google.gms.google-services")
+    apply(plugin = "com.google.firebase.crashlytics")
+} else {
+    logger.warn("google-services.json not found. Firebase Gradle plugins are disabled for this build.")
 }
 
 android {


### PR DESCRIPTION
### Motivation
- Prevent Gradle configuration from failing when a local `google-services.json` is intentionally absent so local/CI debug builds can proceed without Firebase configuration.
- Avoid always applying Firebase Gradle plugins at configuration time which requires the file to exist.

### Description
- Mark `com.google.gms.google-services` and `com.google.firebase.crashlytics` plugin aliases as `apply false` in `app/build.gradle.kts` so they are not forced on every configuration.
- Add a `hasGoogleServicesJson` check that scans common locations (`google-services.json`, `src/google-services.json`, `src/debug/google-services.json`, `src/release/google-services.json`) and conditionally applies the Firebase plugins only when the file exists.
- Emit a clear Gradle warning `google-services.json not found. Firebase Gradle plugins are disabled for this build.` when the file is missing.

### Testing
- Ran `./gradlew :app:assembleDebug -x lint` which no longer fails at `:app:processDebugGoogleServices` due to a missing `google-services.json` and logs the warning instead, confirming the conditional plugin behavior. (Succeeded for the Firebase-missing issue.)
- The build in this environment then stops with an unrelated error about the Android SDK location (`ANDROID_HOME` / `local.properties sdk.dir`), which is outside the scope of this change. (Failure unrelated to this PR.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995d8d77f588324a0961224ca9b68cd)