### PR TITLE
fix: update OpenRouter referer header to LastChat GitHub URL

### DIFF
--- a/ai/src/main/java/me/rerere/ai/util/Request.kt
+++ b/ai/src/main/java/me/rerere/ai/util/Request.kt
@@ -31,7 +31,7 @@ fun Request.Builder.configureReferHeaders(url: String): Request.Builder {
         "openrouter.ai" -> {
             this
                 .addHeader("X-Title", "LastChat")
-                .addHeader("HTTP-Referer", "https://rikka-ai.com")
+                .addHeader("HTTP-Referer", "https://github.com/Cocolalilal/LastChat")
         }
 
         else -> this


### PR DESCRIPTION
### Motivation
- Ensure requests to OpenRouter are attributed to LastChat by using a LastChat-owned referer URL instead of the previous RikkaHub URL.

### Description
- Update `ai/src/main/java/me/rerere/ai/util/Request.kt` to set `HTTP-Referer` for `openrouter.ai` requests to `https://github.com/Cocolalilal/LastChat` while keeping `X-Title: LastChat` unchanged.

### Testing
- Attempted to compile the `ai` module with `./gradlew :ai:compileDebugKotlin`, which failed in this environment due to missing Android SDK configuration (`ANDROID_HOME`/`local.properties`), so no successful compile was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb4d8cd5c832482e032b770387671)