### PR TITLE
fix: polish graph memory person sheet and swipe list behavior

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/GraphMemorySubPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/GraphMemorySubPage.kt
@@ -537,8 +537,17 @@ private fun EntitiesView(
 
     val filteredNodes = nodes
         .filter { node ->
+            val displayName = profilesByNodeId[node.id]
+                ?.displayName
+                ?.takeIf { it.isNotBlank() }
+                ?: node.name
             (selectedType == null || node.nodeType == selectedType) &&
-            (searchQuery.isBlank() || node.name.contains(searchQuery, ignoreCase = true) || node.description.contains(searchQuery, ignoreCase = true))
+            (
+                searchQuery.isBlank() ||
+                    displayName.contains(searchQuery, ignoreCase = true) ||
+                    node.name.contains(searchQuery, ignoreCase = true) ||
+                    node.description.contains(searchQuery, ignoreCase = true)
+                )
         }
         .sortedWith(compareByDescending<MemoryNodeEntity> {
             val p = profilesByNodeId[it.id]
@@ -1050,7 +1059,6 @@ private fun EntitiesView(
         // Node list with swipe-to-delete
         Column(
             modifier = Modifier
-                .clip(RoundedCornerShape(20.dp))
                 .animateContentSize(),
             verticalArrangement = Arrangement.spacedBy(3.dp)
         ) {
@@ -1164,6 +1172,11 @@ private fun NodeCard(
 ) {
     val shape = cardShape(position)
     val typeColor = nodeTypeColor(node.nodeType)
+    val displayName = if (node.nodeType == NodeType.PERSON) {
+        profile?.displayName?.takeIf { it.isNotBlank() } ?: node.name
+    } else {
+        node.name
+    }
     val valenceColor = when {
         node.emotionalValence > 0.3f -> Color(0xFF4CAF50).copy(alpha = 0.08f)
         node.emotionalValence < -0.3f -> Color(0xFFF44336).copy(alpha = 0.08f)
@@ -1218,7 +1231,7 @@ private fun NodeCard(
                         horizontalArrangement = Arrangement.spacedBy(6.dp)
                     ) {
                         Text(
-                            text = node.name,
+                            text = displayName,
                             style = MaterialTheme.typography.titleSmall,
                             fontWeight = FontWeight.Bold,
                             maxLines = 1,
@@ -1695,7 +1708,7 @@ private fun RelationshipsView(
         }
 
         Column(
-            modifier = Modifier.clip(RoundedCornerShape(20.dp)).animateContentSize(),
+            modifier = Modifier.animateContentSize(),
             verticalArrangement = Arrangement.spacedBy(3.dp)
         ) {
             if (sortedEdges.isEmpty()) {
@@ -2094,7 +2107,7 @@ private fun TimelineView(
     }
 
     Column(
-        modifier = Modifier.clip(RoundedCornerShape(20.dp)).animateContentSize(),
+        modifier = Modifier.animateContentSize(),
         verticalArrangement = Arrangement.spacedBy(3.dp)
     ) {
         if (sortedEvents.isEmpty()) {
@@ -2411,7 +2424,7 @@ private fun EpisodesView(
     }
 
     Column(
-        modifier = Modifier.clip(RoundedCornerShape(20.dp)).animateContentSize(),
+        modifier = Modifier.animateContentSize(),
         verticalArrangement = Arrangement.spacedBy(3.dp)
     ) {
         if (sortedEpisodes.isEmpty()) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/PersonProfileSheet.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/PersonProfileSheet.kt
@@ -209,7 +209,7 @@ private fun ProfileViewMode(
             .fillMaxWidth()
             .verticalScroll(scrollState)
             .padding(horizontal = 20.dp)
-            .padding(bottom = 24.dp)
+            .padding(top = 12.dp, bottom = 24.dp)
             .navigationBarsPadding()
             .animateContentSize(animationSpec = spring(dampingRatio = 0.5f, stiffness = 400f)),
         verticalArrangement = Arrangement.spacedBy(16.dp),


### PR DESCRIPTION
### Motivation

- Prevent avatar/header in the person profile sheet from sitting flush against the top edge so the popup feels visually balanced.
- Ensure renamed person identities (`displayName`) are reflected in the entities list and searchable so UI shows edits consistently.
- Stop left-edge cutoff during the drag-to-delete gesture in list views by removing clipping that trims the swipe reveal area.

### Description

- Use a person's profile `displayName` (when non-blank) for the entity title and include it in the search matching in `GraphMemorySubPage` by checking `profilesByNodeId[node.id]?.displayName` before falling back to `node.name`.
- Replace usages of `node.name` with the derived `displayName` in `NodeCard` so person nodes show the edited identity.
- Remove `.clip(RoundedCornerShape(20.dp))` wrappers around the swipeable list containers in the Entities, Relationships, Timeline, and Episodes sections to avoid clipping the left-side reveal during `PhysicsSwipeToDelete` gestures.
- Add top padding to the person profile sheet content in `PersonProfileSheet` by changing the Column padding to `.padding(top = 12.dp, bottom = 24.dp)` so the avatar/header is no longer tight to the sheet top.

### Testing

- Attempted `./gradlew :app:compileDebugKotlin`; the build could not complete in this environment due to missing Android SDK configuration (`ANDROID_HOME` or `local.properties` `sdk.dir`).
- Verified changes via static inspection and grep searches to ensure `displayName` was used in search and rendering and that clipping calls were removed; no instrumented or local builds succeeded because of the SDK limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cbfac5c888324b5afb2a693e2f8a6)