### PR TITLE
Fix OpenRouter identification headers for embeddings and images

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/OpenAIProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/OpenAIProvider.kt
@@ -23,6 +23,7 @@ import me.rerere.ai.ui.MessageChunk
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.util.KeyRoulette
 import me.rerere.ai.util.configureClientWithProxy
+import me.rerere.ai.util.configureReferHeaders
 import me.rerere.ai.util.json
 import me.rerere.ai.util.mergeCustomBody
 import me.rerere.ai.util.toHeaders
@@ -85,6 +86,7 @@ class OpenAIProvider(
         val request = Request.Builder()
             .url(url)
             .addHeader("Authorization", "Bearer $key")
+            .configureReferHeaders(providerSetting.baseUrl)
             .get()
             .build()
 
@@ -150,6 +152,7 @@ class OpenAIProvider(
         val request = Request.Builder()
             .url(url)
             .addHeader("Authorization", "Bearer $key")
+            .configureReferHeaders(providerSetting.baseUrl)
             .get()
             .build()
         val response = client.configureClientWithProxy(providerSetting.proxy).newCall(request).await()
@@ -243,6 +246,7 @@ class OpenAIProvider(
             .addHeader("Authorization", "Bearer $key")
             .addHeader("Content-Type", "application/json")
             .post(requestBody.toRequestBody("application/json".toMediaType()))
+            .configureReferHeaders(providerSetting.baseUrl)
             .build()
 
         val response = client.configureClientWithProxy(providerSetting.proxy).newCall(request).await()
@@ -288,6 +292,7 @@ class OpenAIProvider(
             .addHeader("Authorization", "Bearer $key")
             .addHeader("Content-Type", "application/json")
             .post(requestBody.toRequestBody("application/json".toMediaType()))
+            .configureReferHeaders(providerSetting.baseUrl)
             .build()
 
         val response =


### PR DESCRIPTION
This PR ensures that the app is correctly identified as "LastChat" on OpenRouter for all API calls, including embeddings, image generation, and model listing. Previously, these headers were missing for these specific endpoints, causing the app to appear as "Unknown" or fall back to legacy identifiers.

---
*PR created automatically by Jules for task [12046389435917943068](https://jules.google.com/task/12046389435917943068) started by @Cocolalilal*