### PR TITLE
Updating main branch

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/repository/ConversationRepository.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/repository/ConversationRepository.kt
@@ -5,6 +5,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -501,6 +502,63 @@ class ConversationRepository(
     fun getUsageStatsFlow(): Flow<UsageStatsEntity?> = usageStatsDAO.getStatsFlow()
 
     /**
+     * 12-month rolling usage stats for the statistics page.
+     * Window is calendar-aligned: current month + previous 11 months.
+     */
+    fun getUsageStatsLast12MonthsFlow(): Flow<UsageStatsEntity> = combine(
+        conversationDAO.getAll(),
+        dailyActivityDAO.getAllActivityFlow(),
+        usageStatsDAO.getStatsFlow()
+    ) { allConversations, allActivity, persistedStats ->
+        val today = LocalDate.now()
+        val windowStart = today.withDayOfMonth(1).minusMonths(11)
+        val formatter = DateTimeFormatter.ISO_LOCAL_DATE
+
+        val conversationCountInWindow = allConversations.count { entity ->
+            val createdDate = Instant.ofEpochMilli(entity.createAt)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate()
+            !createdDate.isBefore(windowStart) && !createdDate.isAfter(today)
+        }.toLong()
+
+        val usageTotalsInWindow = allConversations.fold(HistoricalUsageTotals()) { acc, entity ->
+            val fallbackDate = Instant.ofEpochMilli(entity.createAt)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate()
+            acc + extractHistoricalUsage(
+                nodesJson = entity.nodes,
+                windowStart = windowStart,
+                windowEnd = today,
+                fallbackDate = fallbackDate
+            )
+        }
+
+        val messagesFromActivityInWindow = allActivity.sumOf { entity ->
+            val date = runCatching { LocalDate.parse(entity.date, formatter) }.getOrNull()
+            if (date != null && !date.isBefore(windowStart) && !date.isAfter(today)) {
+                entity.messageCount.toLong()
+            } else {
+                0L
+            }
+        }
+
+        val bestMessageCount = maxOf(
+            messagesFromActivityInWindow,
+            usageTotalsInWindow.selectedMessageCount.toLong()
+        )
+
+        UsageStatsEntity(
+            id = 1,
+            totalConversations = conversationCountInWindow,
+            totalMessages = bestMessageCount,
+            inputTokens = usageTotalsInWindow.inputTokens,
+            outputTokens = usageTotalsInWindow.outputTokens,
+            cachedTokens = usageTotalsInWindow.cachedTokens,
+            appLaunches = persistedStats?.appLaunches ?: 0L
+        )
+    }
+
+    /**
      * One-time backfill for legacy/imported databases where usage_stats may exist but lacks token data.
      * Keeps counters monotonic by never decreasing existing values.
      */
@@ -561,7 +619,12 @@ class ConversationRepository(
         usageStatsDAO.incrementAppLaunches()
     }
 
-    private fun extractHistoricalUsage(nodesJson: String): HistoricalUsageTotals {
+    private fun extractHistoricalUsage(
+        nodesJson: String,
+        windowStart: LocalDate? = null,
+        windowEnd: LocalDate? = null,
+        fallbackDate: LocalDate? = null
+    ): HistoricalUsageTotals {
         val root = runCatching { JsonInstant.parseToJsonElement(nodesJson) }.getOrNull()
         if (root !is JsonArray) return HistoricalUsageTotals()
 
@@ -578,6 +641,17 @@ class ConversationRepository(
             val selectedIndex = node["selectIndex"]?.jsonPrimitiveOrNull?.intOrNull ?: 0
             val selectedMessage = (messages.getOrNull(selectedIndex) ?: messages.lastOrNull()) as? JsonObject
                 ?: return@forEach
+
+            val messageDate = parseDateString(
+                selectedMessage["createdAt"]?.jsonPrimitiveOrNull?.contentOrNull
+            )?.let { runCatching { LocalDate.parse(it, DateTimeFormatter.ISO_LOCAL_DATE) }.getOrNull() }
+                ?: fallbackDate
+            if (windowStart != null) {
+                if (messageDate == null || messageDate.isBefore(windowStart)) return@forEach
+            }
+            if (windowEnd != null) {
+                if (messageDate == null || messageDate.isAfter(windowEnd)) return@forEach
+            }
 
             selectedMessageCount += 1
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/MinimalChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/MinimalChatInput.kt
@@ -117,6 +117,7 @@ import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.Conversation
 import me.rerere.rikkahub.service.ChatService
 import me.rerere.rikkahub.ui.components.crop.CropImageScreen
+import me.rerere.rikkahub.ui.components.ui.icons.ModeIcons
 import me.rerere.rikkahub.ui.components.ui.permission.PermissionCamera
 import me.rerere.rikkahub.ui.components.ui.permission.PermissionManager
 import me.rerere.rikkahub.ui.components.ui.permission.rememberPermissionState
@@ -802,16 +803,22 @@ private fun MinimalPickerContent(
         )
         
         // Modes - use enabledModeIds from conversation or default modes
-        val activeModesCount = if (conversation.enabledModeIds.isNotEmpty()) {
-            conversation.enabledModeIds.size
+        val activeModes = if (conversation.enabledModeIds.isNotEmpty()) {
+            settings.modes.filter { mode -> conversation.enabledModeIds.contains(mode.id) }
         } else {
-            settings.modes.count { it.defaultEnabled }
+            settings.modes.filter { it.defaultEnabled }
         }
+        val activeModesCount = activeModes.size
         val modesActive = activeModesCount > 0
+        val singleActiveModeIcon = activeModes.singleOrNull()?.icon
         MinimalPickerItem(
             icon = {
                 Icon(
-                    imageVector = Icons.Rounded.FlashOn,
+                    imageVector = if (singleActiveModeIcon != null) {
+                        ModeIcons.getIcon(singleActiveModeIcon)
+                    } else {
+                        Icons.Rounded.FlashOn
+                    },
                     contentDescription = null,
                     modifier = Modifier.size(24.dp),
                     tint = if (modesActive) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatMessageV2.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatMessageV2.kt
@@ -109,19 +109,21 @@ data class MessageTurnGroup(
     val filteredNodes: List<MessageNode> get() {
         val tag = activeVersionTag
         return nodes.mapNotNull { node ->
-            if (tag == null) {
-                // Active version is null-tagged (old version before versioning)
-                // Find the first message with null versionTag
-                val index = node.messages.indexOfFirst { it.versionTag == null }
-                if (index != -1) {
-                    node.copy(selectIndex = index)
-                } else null
+            val currentIndexMatchesTag = node.messages
+                .getOrNull(node.selectIndex)
+                ?.versionTag == tag
+            val matchingIndex = if (currentIndexMatchesTag) {
+                // Keep the node's active selection when it already matches this turn's tag.
+                node.selectIndex
             } else {
-                // Active version has a tag, find message with matching tag
-                val index = node.messages.indexOfFirst { it.versionTag == tag }
-                if (index != -1) {
-                    node.copy(selectIndex = index)
-                } else null
+                // Fall back to the newest matching message (important for same-tag edits).
+                node.messages.indexOfLast { it.versionTag == tag }
+            }
+
+            if (matchingIndex != -1) {
+                node.copy(selectIndex = matchingIndex)
+            } else {
+                null
             }
         }
     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantAdvancedSubPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantAdvancedSubPage.kt
@@ -33,16 +33,17 @@ fun AssistantAdvancedSubPage(
             .imePadding(),
         verticalArrangement = Arrangement.spacedBy(0.dp)
     ) {
-        // Message formatting settings moved from Prompts tab
-        MessageTemplateSettingsCard(
-            assistant = assistant,
-            onUpdate = onUpdate
-        )
+        SettingsGroup(title = "Message Formatting") {
+            MessageTemplateSettingsCard(
+                assistant = assistant,
+                onUpdate = onUpdate
+            )
 
-        MessageRegexSettingsCard(
-            assistant = assistant,
-            onUpdate = onUpdate
-        )
+            MessageRegexSettingsCard(
+                assistant = assistant,
+                onUpdate = onUpdate
+            )
+        }
 
         // Custom request settings
         SettingsGroup(title = "Custom Request") {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMessageFormattingSettings.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMessageFormattingSettings.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Delete
@@ -41,25 +42,38 @@ import me.rerere.rikkahub.data.model.AssistantAffectScope
 import me.rerere.rikkahub.data.model.AssistantRegex
 import me.rerere.rikkahub.ui.components.ui.DebouncedTextField
 import me.rerere.rikkahub.ui.components.ui.HapticSwitch
+import me.rerere.rikkahub.ui.theme.LocalDarkMode
 
 @Composable
 fun MessageTemplateSettingsCard(
     assistant: Assistant,
     onUpdate: (Assistant) -> Unit
 ) {
-    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            color = MaterialTheme.colorScheme.surfaceContainerHigh,
-            shape = me.rerere.rikkahub.ui.theme.AppShapes.CardLarge
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = if (LocalDarkMode.current) {
+            MaterialTheme.colorScheme.surfaceContainerLow
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHighest
+        },
+        shape = RoundedCornerShape(10.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            Column(
-                modifier = Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Text(stringResource(R.string.assistant_page_message_template), style = MaterialTheme.typography.titleMedium)
-                Text(stringResource(R.string.assistant_page_message_template_desc), style = MaterialTheme.typography.bodyMedium)
-                Text(buildAnnotatedString {
+            Text(
+                text = stringResource(R.string.assistant_page_message_template),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = stringResource(R.string.assistant_page_message_template_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                buildAnnotatedString {
                     append(stringResource(R.string.assistant_page_template_variables_label)); append(" ")
                     append(stringResource(R.string.assistant_page_template_variable_role)); append(": ")
                     withStyle(SpanStyle(color = MaterialTheme.colorScheme.primary)) { append("{{ role }}") }
@@ -72,16 +86,18 @@ fun MessageTemplateSettingsCard(
                     append(", ")
                     append(stringResource(R.string.assistant_page_template_variable_date)); append(": ")
                     withStyle(SpanStyle(color = MaterialTheme.colorScheme.primary)) { append("{{ date }}") }
-                }, style = MaterialTheme.typography.bodySmall)
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
 
-                DebouncedTextField(
-                    value = assistant.messageTemplate,
-                    onValueChange = { onUpdate(assistant.copy(messageTemplate = it)) },
-                    stateKey = "advanced_message_template_${assistant.id}",
-                    modifier = Modifier.fillMaxWidth(),
-                    maxLines = 8
-                )
-            }
+            DebouncedTextField(
+                value = assistant.messageTemplate,
+                onValueChange = { onUpdate(assistant.copy(messageTemplate = it)) },
+                stateKey = "advanced_message_template_${assistant.id}",
+                modifier = Modifier.fillMaxWidth(),
+                maxLines = 8
+            )
         }
     }
 }
@@ -91,28 +107,41 @@ fun MessageRegexSettingsCard(
     assistant: Assistant,
     onUpdate: (Assistant) -> Unit
 ) {
-    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            color = MaterialTheme.colorScheme.surfaceContainerHigh,
-            shape = me.rerere.rikkahub.ui.theme.AppShapes.CardLarge
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = if (LocalDarkMode.current) {
+            MaterialTheme.colorScheme.surfaceContainerLow
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHighest
+        },
+        shape = RoundedCornerShape(10.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(stringResource(R.string.assistant_page_regex_title), style = MaterialTheme.typography.titleMedium)
-                Text(stringResource(R.string.assistant_page_regex_desc), style = MaterialTheme.typography.bodyMedium)
+            Text(
+                text = stringResource(R.string.assistant_page_regex_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = stringResource(R.string.assistant_page_regex_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
 
-                assistant.regexes.fastForEachIndexed { index, regex ->
-                    RegexEditorCard(regex = regex, assistant = assistant, index = index, onUpdate = onUpdate)
-                }
+            assistant.regexes.fastForEachIndexed { index, regex ->
+                RegexEditorCard(regex = regex, assistant = assistant, index = index, onUpdate = onUpdate)
+            }
 
-                Button(
-                    onClick = {
-                        onUpdate(assistant.copy(regexes = assistant.regexes + AssistantRegex(id = Uuid.random())))
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Icon(Icons.Rounded.Add, contentDescription = null)
-                }
+            Button(
+                onClick = {
+                    onUpdate(assistant.copy(regexes = assistant.regexes + AssistantRegex(id = Uuid.random())))
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(Icons.Rounded.Add, contentDescription = null)
             }
         }
     }
@@ -129,8 +158,8 @@ private fun RegexEditorCard(
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = androidx.compose.foundation.shape.RoundedCornerShape(10.dp),
-        color = MaterialTheme.colorScheme.background
+        shape = RoundedCornerShape(10.dp),
+        color = MaterialTheme.colorScheme.surface
     ) {
         Column(
             modifier = Modifier.padding(12.dp).animateContentSize(),

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantToolsSubPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantToolsSubPage.kt
@@ -4,31 +4,47 @@ import android.Manifest
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import me.rerere.rikkahub.ui.components.ui.HapticSwitch
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import me.rerere.rikkahub.R
+import me.rerere.rikkahub.data.ai.mcp.McpManager
 import me.rerere.rikkahub.data.ai.mcp.McpServerConfig
+import me.rerere.rikkahub.data.ai.mcp.McpStatus
 import me.rerere.rikkahub.data.ai.tools.LocalToolOption
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.AssistantSearchMode
-import me.rerere.rikkahub.ui.components.ai.McpPickerButton
+import me.rerere.rikkahub.ui.components.ai.McpPicker
 import me.rerere.rikkahub.ui.components.ui.Select
 import me.rerere.rikkahub.ui.pages.setting.components.SettingsGroup
 import me.rerere.rikkahub.ui.pages.setting.components.SettingGroupItem
 import me.rerere.search.SearchServiceOptions
+import org.koin.compose.koinInject
 
 /**
  * Tools & Search tab - Combined search, local tools, and MCP settings.
@@ -190,19 +206,70 @@ fun AssistantToolsSubPage(
         // MCP GROUP (only show if servers configured)
         // ═══════════════════════════════════════════════════════════════════
         if (mcpServerConfigs.isNotEmpty()) {
+            var showMcpPicker by remember { mutableStateOf(false) }
+            val mcpManager = koinInject<McpManager>()
+            val syncingStatus by mcpManager.syncingStatus.collectAsStateWithLifecycle()
+            val loading = syncingStatus.values.any { it == McpStatus.Connecting }
+            val availableServerCount = mcpServerConfigs.count { it.commonOptions.enable }
+            val enabledServerCount = mcpServerConfigs.count {
+                it.commonOptions.enable && assistant.mcpServers.contains(it.id)
+            }
+
             SettingsGroup(title = stringResource(R.string.assistant_page_tab_mcp)) {
-            SettingGroupItem(
-                    title = "MCP Servers",
-                    subtitle = "Enable external tool servers",
-                    trailing = {
-                        McpPickerButton(
+                SettingGroupItem(
+                    title = stringResource(R.string.mcp_picker_title),
+                    subtitle = when {
+                        loading -> stringResource(R.string.mcp_picker_syncing)
+                        enabledServerCount > 0 -> "$enabledServerCount enabled of $availableServerCount"
+                        else -> "Select external tool servers"
+                    },
+                    onClick = { showMcpPicker = true }
+                )
+            }
+
+            if (showMcpPicker) {
+                ModalBottomSheet(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    onDismissRequest = { showMcpPicker = false },
+                    sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .fillMaxHeight(0.7f)
+                            .padding(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.mcp_picker_title),
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontWeight = FontWeight.Bold
+                            ),
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        AnimatedVisibility(loading) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(4.dp),
+                                modifier = Modifier.padding(vertical = 4.dp)
+                            ) {
+                                LinearWavyProgressIndicator()
+                                Text(
+                                    text = stringResource(id = R.string.mcp_picker_syncing),
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                            }
+                        }
+                        McpPicker(
                             assistant = assistant,
                             servers = mcpServerConfigs,
-                            mcpManager = org.koin.compose.koinInject(),
-                            onUpdateAssistant = onUpdate
+                            onUpdateAssistant = onUpdate,
+                            modifier = Modifier
+                                .fillMaxWidth()
                         )
                     }
-                )
+                }
             }
         }
     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/menu/MenuVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/menu/MenuVM.kt
@@ -39,7 +39,7 @@ class MenuVM(
 
     val stats: StateFlow<MenuStats> = combine(
         conversationRepository.getDailyActivityDatesFlow(),
-        conversationRepository.getUsageStatsFlow(),
+        conversationRepository.getUsageStatsLast12MonthsFlow(),
         conversationRepository.getAllDailyActivityFlow()
     ) { distinctDates, usageStats, allActivity ->
         // Daily Chat Streak
@@ -56,7 +56,8 @@ class MenuVM(
             }
         }
         val activityMap = parsedActivity.toMap()
-        val heatmapStartDate = today.minusMonths(11)
+        val strictWindowStartDate = today.withDayOfMonth(1).minusMonths(11)
+        val heatmapStartDate = strictWindowStartDate
             .with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY))
         
         val heatmapData = generateSequence(heatmapStartDate) { it.plusDays(1) }
@@ -64,14 +65,14 @@ class MenuVM(
             .map { date ->
                 HeatmapDay(
                     date = date,
-                    count = activityMap[date] ?: 0
+                    count = if (date.isBefore(strictWindowStartDate)) 0 else (activityMap[date] ?: 0)
                 )
             }
             .toList()
 
         MenuStats(
             dailyChatStreak = streak,
-            usageStats = usageStats ?: UsageStatsEntity(),
+            usageStats = usageStats,
             heatmapData = heatmapData
         )
     }


### PR DESCRIPTION
Introduce a calendar-aligned 12-month rolling usage flow and related parsing changes: add getUsageStatsLast12MonthsFlow in ConversationRepository, update extractHistoricalUsage to accept window bounds and fallback date, and compute conversation/message/token totals for the window. Update MenuVM to use the new flow and align the heatmap start to the strict 12-month window (zeroing counts before the window). UI tweaks: MinimalChatInput now computes active modes list and shows a mode icon via ModeIcons when a single mode is active. Fix message selection logic in ChatMessageV2 to prefer the node's current selection when it matches the active version tag and otherwise pick the newest matching message. Assistant pages restyled: group message formatting settings, adjust surfaces, colors and shapes, and improve regex editor layout. Add an MCP picker modal in AssistantToolsSubPage with sync status (including progress indicator) using McpManager.