### PR TITLE
fix: keep drawer search bar position stable

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationList.kt
@@ -139,11 +139,13 @@ fun ColumnScope.ConversationList(
         }
     }
 
-    // fix: compose很奇怪，会自动聚焦到第一个文本框
-    // 在这里放一个空的Box，防止自动聚焦到第一个文本框弹出IME
-    if (!isSearchExpanded) {
-        Box(modifier = Modifier.focusable())
-    }
+    // Keep a zero-height focus target to prevent auto-focusing the search field
+    // without introducing layout jumps when search enters/leaves expanded state.
+    Box(
+        modifier = Modifier
+            .height(0.dp)
+            .focusable()
+    )
 
     Row(
         verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
### Motivation
- Prevent the small vertical jump of the drawer search input when expanding search so the spacing between the search bar, the user avatar above, and the Imagine button below remains constant by avoiding conditional layout changes.

### Description
- Replace the conditional focus-guard `Box` with a permanently mounted zero-height focusable `Box` (`.height(0.dp).focusable()`) in `ConversationList.kt` so the search field does not cause layout shifts when it gains focus.

### Testing
- Attempted to compile with `./gradlew :app:compileDebugKotlin`, which could not complete in this environment due to a missing Android SDK (`SDK location not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98f45c194832481b9d55c21a229a4)