### PR TITLE
Fix preset providers automatically re-adding

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/LastChatApp.kt
+++ b/app/src/main/java/me/rerere/rikkahub/LastChatApp.kt
@@ -181,7 +181,6 @@ class LastChatApp : Application() {
                         settings = settings,
                         snapshot = snapshot,
                         resolver = get<ModelMetadataResolver>(),
-                        includeMissingCatalogProviders = false,
                     )
                 )
             }.onFailure {

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/models/CatalogSettingsMerger.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/models/CatalogSettingsMerger.kt
@@ -10,7 +10,7 @@ fun mergeCatalogIntoSettings(
     settings: Settings,
     snapshot: ModelCatalogSnapshot,
     resolver: ModelMetadataResolver,
-    includeMissingCatalogProviders: Boolean = true,
+    includeMissingCatalogProviders: Boolean = false,
 ): Settings {
     val catalogProvidersById = snapshot.providers
         .mapNotNull { provider -> provider.uuidOrNull()?.let { it to provider } }

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/models/ModelMetadataResolverTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/models/ModelMetadataResolverTest.kt
@@ -769,7 +769,6 @@ class ModelMetadataResolverTest {
             settings = Settings(providers = listOf(existing)),
             snapshot = snapshot,
             resolver = resolver,
-            includeMissingCatalogProviders = false,
         )
 
         assertEquals(1, merged.providers.size)


### PR DESCRIPTION
Fixes an issue where all available preset providers get added back to the user's provider list periodically when the model catalog refreshes.

---
*PR created automatically by Jules for task [14507660807533728896](https://jules.google.com/task/14507660807533728896) started by @Cocolalilal*